### PR TITLE
fix(P1-F18): preserve yield in lastTotalAssets across deposit/withdraw

### DIFF
--- a/src/PaktolVault.sol
+++ b/src/PaktolVault.sol
@@ -312,6 +312,18 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
 
     /* ──────────────────────── DEPOSIT / WITHDRAW ───────────────────── */
 
+    /// @dev Updates lastTotalAssets by a signed delta instead of re-reading totalAssets().
+    ///      Preserves accumulated yield that has already been computed by harvest()
+    ///      and must not be overwritten by a subsequent deposit or withdrawal.
+    function _syncLastTotalAssets(int256 delta) internal {
+        if (delta >= 0) {
+            lastTotalAssets += uint256(delta);
+        } else {
+            uint256 decrease = uint256(-delta);
+            lastTotalAssets = lastTotalAssets > decrease ? lastTotalAssets - decrease : 0;
+        }
+    }
+
     /// @dev Shared deposit logic — called by deposit() and depositWithPermit().
     ///      Assumes caller holds nonReentrant lock and whenNotPaused check has passed.
     function _executeDeposit(
@@ -325,7 +337,7 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         }
         uint256 shares = super.deposit(assets, receiver);
         _depositToAave();
-        lastTotalAssets = totalAssets();
+        _syncLastTotalAssets(int256(assets));
         return shares;
     }
 
@@ -414,7 +426,7 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         }
         uint256 assetsUsed = super.mint(shares, receiver);
         _depositToAave();
-        lastTotalAssets = totalAssets();
+        _syncLastTotalAssets(int256(assetsUsed));
         return assetsUsed;
     }
 
@@ -425,7 +437,7 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         address owner_
     ) public override nonReentrant returns (uint256) {
         uint256 shares = super.withdraw(assets, receiver, owner_);
-        lastTotalAssets = totalAssets();
+        _syncLastTotalAssets(-int256(assets));
         return shares;
     }
 
@@ -436,7 +448,7 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         address owner_
     ) public override nonReentrant returns (uint256) {
         uint256 assets = super.redeem(shares, receiver, owner_);
-        lastTotalAssets = totalAssets();
+        _syncLastTotalAssets(-int256(assets));
         return assets;
     }
 

--- a/test/PaktolVault.t.sol
+++ b/test/PaktolVault.t.sol
@@ -650,6 +650,65 @@ contract PaktolVaultTest is Test {
         assertApproxEqAbs(vaultStd.convertToAssets(shares2), DEPOSIT, 1e9);
     }
 
+    /* ─────────────── F-18: lastTotalAssets accounting invariant ─────── */
+
+    /// @dev Proves that a deposit between yield accrual and harvest does NOT
+    ///      absorb the pending yield into lastTotalAssets (old bug: always wrote
+    ///      totalAssets() after deposit, which erased the accrued gap).
+    ///
+    ///      Timeline:
+    ///        t0  user deposits 1 000 EURe → lastTotalAssets = 1 000
+    ///        t1  AAVE accrues 50 EURe     → totalAssets = 1 050, lastTotalAssets = 1 000
+    ///        t2  user2 deposits 200 EURe  → lastTotalAssets must stay 1 200 (not 1 250)
+    ///        t3  harvest sees grossYield = 50 EURe → treasury receives correct share
+    function test_f18_deposit_does_not_absorb_pending_yield() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        assertEq(vaultStd.lastTotalAssets(), DEPOSIT);
+
+        uint256 yieldAmount = 50e18;
+        _simulateYield(vaultStd, yieldAmount);
+        // totalAssets = 1050, but lastTotalAssets must still be 1000
+
+        uint256 deposit2 = 200e18;
+        eure.mint(user2, deposit2);
+        _deposit(vaultStd, user2, deposit2);
+
+        // Fix: lastTotalAssets = 1000 + 200 = 1200 (yield gap preserved)
+        // Bug: lastTotalAssets = totalAssets() = 1250 (yield absorbed)
+        assertEq(vaultStd.lastTotalAssets(), DEPOSIT + deposit2, "deposit must not absorb pending yield");
+
+        _warp(365 days);
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        // grossYield = 1250 - 1200 = 50 EURe → treasury receives non-zero
+        // (bug: grossYield = 1250 - 1250 = 0 → treasury gets nothing)
+        assertGt(eure.balanceOf(treasury), 0, "treasury must receive yield from pre-deposit accumulation");
+    }
+
+    /// @dev Proves that a partial withdrawal does NOT absorb pending yield.
+    function test_f18_withdraw_does_not_absorb_pending_yield() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _deposit(vaultStd, user2, DEPOSIT);
+
+        uint256 yieldAmount = 50e18;
+        _simulateYield(vaultStd, yieldAmount);
+
+        uint256 withdrawAmount = 200e18;
+        vm.prank(user);
+        vaultStd.withdraw(withdrawAmount, user, user);
+
+        // Fix: lastTotalAssets = 2000 - 200 = 1800 (yield gap preserved)
+        // Bug: lastTotalAssets = totalAssets() = 1850 (yield absorbed)
+        assertEq(vaultStd.lastTotalAssets(), 2 * DEPOSIT - withdrawAmount, "withdraw must not absorb pending yield");
+
+        _warp(365 days);
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertGt(eure.balanceOf(treasury), 0, "treasury must receive yield from pre-withdrawal accumulation");
+    }
+
     /* ─────────────────────── FUZZ ───────────────────────────────────── */
 
     function testFuzz_deposit_withdraw_roundtrip(


### PR DESCRIPTION
## Summary

- Replaces `lastTotalAssets = totalAssets()` with `_syncLastTotalAssets(delta)` in `_executeDeposit`, `mint`, `withdraw`, and `redeem`
- Overwriting the snapshot with `totalAssets()` silently absorbed accrued yield into `lastTotalAssets`, causing `harvest()` to see `grossYield = 0`
- The new helper adjusts `lastTotalAssets` by the exact amount moved in or out, leaving the accrued yield gap intact for the next harvest

## Test plan

- [ ] `test_f18_deposit_does_not_absorb_pending_yield` — deposit between yield accrual and harvest: treasury receives correct share
- [ ] `test_f18_withdraw_does_not_absorb_pending_yield` — withdrawal between yield accrual and harvest: treasury receives correct share
- [ ] All 75 existing unit tests pass

Closes #6