### PR TITLE
fix(P1-F11): atomic auto-pause + accounting reset in emergencyExitAave()

### DIFF
--- a/src/PaktolVault.sol
+++ b/src/PaktolVault.sol
@@ -419,6 +419,8 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     }
 
     /// @notice Withdraw EURe. Always available, even when paused.
+    ///         Intentional design: users must be able to exit at all times per ERC-4626.
+    ///         pause() only blocks new deposits — it does not block withdrawals.
     function withdraw(
         uint256 assets,
         address receiver,
@@ -430,6 +432,8 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     }
 
     /// @notice Redeem shares. Always available, even when paused.
+    ///         Intentional design: users must be able to exit at all times per ERC-4626.
+    ///         pause() only blocks new deposits — it does not block redemptions.
     function redeem(
         uint256 shares,
         address receiver,
@@ -555,19 +559,31 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     /* ────────────────────────── EMERGENCY EXIT ──────────────────────── */
 
     /// @notice Pulls all aEURe out of AAVE back into the vault as idle EURe.
-    ///         Use when AAVE freezes or pauses the EURe market.
+    ///         Automatically pauses deposits if not already paused, so a concurrent
+    ///         deposit cannot immediately re-route funds back into AAVE.
     ///
     ///         Recommended sequence:
-    ///           1. guardian calls pause()       — blocks new deposits
-    ///           2. owner   calls emergencyExitAave() — withdraws all from AAVE
-    ///           3. users   call withdraw() / redeem() — served from idle balance
+    ///           1. owner calls emergencyExitAave() — pauses + withdraws atomically
+    ///           2. users call withdraw() / redeem() — served from idle balance
+    ///              withdraw() and redeem() intentionally omit whenNotPaused: users
+    ///              can always exit regardless of pause state. This is a deliberate
+    ///              ERC-4626 design trade-off; if the withdrawal path itself were
+    ///              compromised, the only mitigation would be a contract upgrade.
+    ///
+    ///         lastTotalAssets and lastHarvestTimestamp are reset to reflect the
+    ///         post-exit state. Any yield accrued since the last harvest is absorbed
+    ///         into the new baseline — this is an acceptable trade-off in an emergency
+    ///         to avoid an additional AAVE interaction that could fail if AAVE is degraded.
     ///
     ///         If AAVE is fully paused (not just frozen), this call will revert.
     ///         In that case there is no on-chain remedy until AAVE unpauses.
     function emergencyExitAave() external onlyOwner nonReentrant {
+        if (!paused()) _pause();
         uint256 aTokenBalance = IERC20(ATOKEN).balanceOf(address(this));
         if (aTokenBalance == 0) return;
         IAavePool(AAVE_POOL).withdraw(asset(), aTokenBalance, address(this));
+        lastTotalAssets = totalAssets();
+        lastHarvestTimestamp = block.timestamp;
         emit EmergencyExitAave(aTokenBalance, block.timestamp);
     }
 }

--- a/test/PaktolVault.t.sol
+++ b/test/PaktolVault.t.sol
@@ -817,6 +817,55 @@ contract PaktolVaultTest is Test {
         vaultStd.emergencyExitAave();
     }
 
+    /// @dev F-11: emergencyExitAave() must pause atomically so a concurrent deposit
+    ///      cannot immediately re-route idle EURe back into AAVE.
+    function test_f11_emergencyExit_autopause() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        assertFalse(vaultStd.paused(), "vault starts unpaused");
+
+        vm.prank(owner);
+        vaultStd.emergencyExitAave();
+
+        assertTrue(vaultStd.paused(), "vault must be paused after emergency exit");
+
+        // Deposit must be blocked — funds cannot re-enter AAVE.
+        vm.startPrank(user);
+        eure.approve(address(vaultStd), DEPOSIT);
+        vm.expectRevert();
+        vaultStd.deposit(DEPOSIT, user);
+        vm.stopPrank();
+    }
+
+    /// @dev F-11: emergencyExitAave() on an already-paused vault must not revert.
+    function test_f11_emergencyExit_alreadyPaused_noRevert() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        // Must not revert even though vault is already paused.
+        vm.prank(owner);
+        vaultStd.emergencyExitAave();
+
+        assertTrue(vaultStd.paused());
+        assertEq(IERC20(vaultStd.ATOKEN()).balanceOf(address(vaultStd)), 0);
+    }
+
+    /// @dev F-11: accounting snapshot after emergency exit is clean.
+    function test_f11_emergencyExit_updatesAccounting() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _simulateYield(vaultStd, 20e18);
+        _warp(7 days);
+
+        uint256 tsBefore = vaultStd.lastHarvestTimestamp();
+
+        vm.prank(owner);
+        vaultStd.emergencyExitAave();
+
+        assertEq(vaultStd.lastTotalAssets(), vaultStd.totalAssets(), "lastTotalAssets must reflect post-exit state");
+        assertGt(vaultStd.lastHarvestTimestamp(), tsBefore, "lastHarvestTimestamp must be reset");
+    }
+
     /* ─────────────────────── depositWithPermit ──────────────────────── */
 
     uint256 constant PERMIT_USER_KEY = 0xA11CE;


### PR DESCRIPTION
## Summary

- `emergencyExitAave()` now calls `_pause()` atomically before the AAVE withdrawal if not already paused
- Without this, a concurrent deposit would call `_depositToAave()` and immediately re-route idle EURe back to AAVE, nullifying the emergency
- `lastTotalAssets` and `lastHarvestTimestamp` are reset after the withdrawal for accounting consistency
- NatSpec on `withdraw()` and `redeem()` explicitly documents that they remain open while paused (deliberate ERC-4626 design trade-off)

## Test plan

- [ ] `test_f11_emergencyExit_autopause` — vault is paused after exit, subsequent deposit reverts
- [ ] `test_f11_emergencyExit_alreadyPaused_noRevert` — calling on an already-paused vault does not revert
- [ ] `test_f11_emergencyExit_updatesAccounting` — `lastTotalAssets` and `lastHarvestTimestamp` reflect post-exit state
- [ ] All 76 unit tests pass

Closes #9