### PR TITLE
fix(P0-F09): 4-hour withdrawal cooldown to prevent harvest sandwich attacks

### DIFF
--- a/src/PaktolVault.sol
+++ b/src/PaktolVault.sol
@@ -466,6 +466,18 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         return assets;
     }
 
+    /// @dev Propagates depositTimestamp on share transfers to prevent cooldown bypass.
+    ///      Without this, an attacker could deposit, transfer shares to a fresh address,
+    ///      and that address would have no cooldown — bypassing the sandwich protection.
+    function _update(address from, address to, uint256 amount) internal override {
+        super._update(from, to, amount);
+        if (from != address(0) && to != address(0)) {
+            if (depositTimestamp[from] > depositTimestamp[to]) {
+                depositTimestamp[to] = depositTimestamp[from];
+            }
+        }
+    }
+
     /// @dev CEI-compliant internal hook called by withdraw() and redeem().
     ///      Shares are burned by OpenZeppelin BEFORE this hook executes,
     ///      so all state updates (Effects) precede external calls (Interactions).

--- a/src/PaktolVault.sol
+++ b/src/PaktolVault.sol
@@ -59,6 +59,12 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     ///         from draining yield to the treasury via high-frequency calls.
     uint256 public constant MIN_HARVEST_INTERVAL = 1 days;
 
+    /// @notice Minimum hold time after a deposit before withdrawal is allowed.
+    ///         Prevents sandwich attacks on harvest(): an attacker depositing just
+    ///         before harvest() cannot withdraw until 4 hours have elapsed.
+    ///         Bypassed when the vault is paused (emergency exit must always be possible).
+    uint256 public constant WITHDRAWAL_COOLDOWN = 4 hours;
+
     /* ─────────────────────────── IMMUTABLES ────────────────────────── */
 
     /// @notice Annual net yield cap in basis points (350 = 3.5% / 500 = 5%).
@@ -102,6 +108,9 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     /// @notice Timestamp of the last harvest.
     uint256 public lastHarvestTimestamp;
 
+    /// @notice Timestamp of the last deposit per address. Used to enforce WITHDRAWAL_COOLDOWN.
+    mapping(address => uint256) public depositTimestamp;
+
     /// @notice Emergency pause address. Cannot move funds.
     address public guardian;
 
@@ -136,6 +145,7 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     error UseDepositWithAuth();
     error InvalidSignature();
     error SignatureExpired();
+    error WithdrawalCooldown(uint256 availableAt);
 
     /* ─────────────────────────── CONSTRUCTOR ───────────────────────── */
 
@@ -239,11 +249,13 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     }
 
     /// @notice Maximum assets owner_ can withdraw, bounded by AAVE available liquidity.
+    ///         Returns 0 if owner_ is within the WITHDRAWAL_COOLDOWN window (vault not paused).
     ///         Returns less than the full position if AAVE liquidity is insufficient.
     ///         Withdrawals are always open (no whenNotPaused).
     function maxWithdraw(
         address owner_
     ) public view override returns (uint256) {
+        if (!paused() && block.timestamp < depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN) return 0;
         uint256 userAssets = convertToAssets(balanceOf(owner_));
         uint256 idle = IERC20(asset()).balanceOf(address(this));
         uint256 aaveLiquidity = IERC20(asset()).balanceOf(ATOKEN);
@@ -254,11 +266,13 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     }
 
     /// @notice Maximum shares owner_ can redeem, bounded by AAVE available liquidity.
+    ///         Returns 0 if owner_ is within the WITHDRAWAL_COOLDOWN window (vault not paused).
     ///         Returns balanceOf(owner_) directly when not liquidity-constrained to
     ///         avoid double-rounding (convertToShares(convertToAssets(x)) < x).
     function maxRedeem(
         address owner_
     ) public view override returns (uint256) {
+        if (!paused() && block.timestamp < depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN) return 0;
         uint256 userShares = balanceOf(owner_);
         uint256 idle = IERC20(asset()).balanceOf(address(this));
         uint256 aaveLiquidity = IERC20(asset()).balanceOf(ATOKEN);
@@ -326,6 +340,7 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         uint256 shares = super.deposit(assets, receiver);
         _depositToAave();
         lastTotalAssets = totalAssets();
+        depositTimestamp[receiver] = block.timestamp;
         return shares;
     }
 
@@ -415,26 +430,37 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         uint256 assetsUsed = super.mint(shares, receiver);
         _depositToAave();
         lastTotalAssets = totalAssets();
+        depositTimestamp[receiver] = block.timestamp;
         return assetsUsed;
     }
 
     /// @notice Withdraw EURe. Always available, even when paused.
+    ///         Intentional design: users must be able to exit at all times per ERC-4626.
+    ///         pause() only blocks new deposits — it does not block withdrawals.
     function withdraw(
         uint256 assets,
         address receiver,
         address owner_
     ) public override nonReentrant returns (uint256) {
+        if (!paused() && block.timestamp < depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN) {
+            revert WithdrawalCooldown(depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN);
+        }
         uint256 shares = super.withdraw(assets, receiver, owner_);
         lastTotalAssets = totalAssets();
         return shares;
     }
 
     /// @notice Redeem shares. Always available, even when paused.
+    ///         Intentional design: users must be able to exit at all times per ERC-4626.
+    ///         pause() only blocks new deposits — it does not block redemptions.
     function redeem(
         uint256 shares,
         address receiver,
         address owner_
     ) public override nonReentrant returns (uint256) {
+        if (!paused() && block.timestamp < depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN) {
+            revert WithdrawalCooldown(depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN);
+        }
         uint256 assets = super.redeem(shares, receiver, owner_);
         lastTotalAssets = totalAssets();
         return assets;

--- a/test/PaktolVault.t.sol
+++ b/test/PaktolVault.t.sol
@@ -892,6 +892,26 @@ contract PaktolVaultTest is Test {
         vaultStd.withdraw(DEPOSIT, user2, user2);
     }
 
+    /// @dev Transfer of shares propagates the sender's depositTimestamp to the receiver.
+    ///      Without this, an attacker could bypass the cooldown by transferring shares
+    ///      to a fresh address that has no depositTimestamp.
+    function test_f09_cooldown_propagated_on_transfer() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        address attacker2 = makeAddr("attacker2");
+
+        // Transfer shares to fresh address — must inherit user's depositTimestamp.
+        vm.prank(user);
+        vaultStd.transfer(attacker2, shares);
+
+        assertEq(vaultStd.depositTimestamp(attacker2), vaultStd.depositTimestamp(user));
+
+        // attacker2 cannot withdraw immediately — cooldown inherited.
+        vm.expectRevert();
+        vm.prank(attacker2);
+        vaultStd.redeem(shares, attacker2, attacker2);
+    }
+
     /// @dev Cooldown is bypassed when vault is paused (emergency exit always possible).
     function test_f09_cooldown_bypassed_when_paused() public {
         uint256 shares = _deposit(vaultStd, user, DEPOSIT);

--- a/test/PaktolVault.t.sol
+++ b/test/PaktolVault.t.sol
@@ -265,6 +265,7 @@ contract PaktolVaultTest is Test {
 
     function test_withdraw_basic() public {
         _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
         uint256 balBefore = eure.balanceOf(user);
 
         vm.prank(user);
@@ -280,7 +281,7 @@ contract PaktolVaultTest is Test {
         vm.prank(guardian);
         vaultStd.pause();
 
-        // Must succeed even while paused.
+        // Cooldown bypassed when paused — must succeed immediately.
         vm.prank(user);
         vaultStd.withdraw(DEPOSIT, user, user);
 
@@ -289,6 +290,7 @@ contract PaktolVaultTest is Test {
 
     function test_redeem_basic() public {
         uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
         uint256 balBefore = eure.balanceOf(user);
 
         vm.prank(user);
@@ -300,6 +302,7 @@ contract PaktolVaultTest is Test {
 
     function test_withdraw_updates_lastTotalAssets() public {
         _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
 
         vm.prank(user);
         vaultStd.withdraw(DEPOSIT / 2, user, user);
@@ -661,6 +664,7 @@ contract PaktolVaultTest is Test {
         uint256 shares = _deposit(vaultStd, user, amount);
         assertApproxEqAbs(vaultStd.totalAssets(), amount, 1e9);
 
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
         vm.prank(user);
         vaultStd.redeem(shares, user, user);
 
@@ -708,18 +712,17 @@ contract PaktolVaultTest is Test {
     /* ─────────────────────── MAX WITHDRAW / REDEEM ──────────────────── */
 
     function test_maxWithdraw_fullLiquidity() public {
-        // AAVE aToken holds >= vault position → user can withdraw full position.
         _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
 
         uint256 expected = vaultStd.convertToAssets(vaultStd.balanceOf(user));
         assertApproxEqAbs(vaultStd.maxWithdraw(user), expected, 1e9);
     }
 
     function test_maxWithdraw_limitedByAaveLiquidity() public {
-        // Drain aToken's EURe backing to simulate shallow AAVE liquidity.
         _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
 
-        // Burn 900 EURe from aToken — only 100 EURe remains available.
         eure.burn(address(pool.aToken()), 900e18);
 
         assertEq(eure.balanceOf(address(pool.aToken())), 100e18);
@@ -732,25 +735,25 @@ contract PaktolVaultTest is Test {
 
     function test_maxRedeem_limitedByAaveLiquidity() public {
         uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
 
-        // Only 100 EURe left in aToken.
         eure.burn(address(pool.aToken()), 900e18);
 
         uint256 maxR = vaultStd.maxRedeem(user);
-        // maxRedeem must be <= actual shares
         assertLe(maxR, shares);
-        // Converting maxRedeem shares → assets should be ~100 EURe
         assertApproxEqAbs(vaultStd.convertToAssets(maxR), 100e18, 1e9);
     }
 
     function test_maxWithdraw_idleCountsTowardLiquidity() public {
-        // Deposit, then simulate vault holding idle EURe (e.g. right after emergencyExit).
         _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(guardian);
+        vaultStd.pause(); // pause so cooldown is bypassed for maxWithdraw
 
         vm.prank(owner);
         vaultStd.emergencyExitAave(); // all funds now idle in vault
 
-        // aToken balance is 0, but idle is 1000 — maxWithdraw should still return full position.
+        // aToken balance is 0, but idle is 1000 — maxWithdraw should return full position.
         uint256 expected = vaultStd.convertToAssets(vaultStd.balanceOf(user));
         assertApproxEqAbs(vaultStd.maxWithdraw(user), expected, 1e9);
     }
@@ -815,6 +818,105 @@ contract PaktolVaultTest is Test {
         vm.expectRevert();
         vm.prank(guardian);
         vaultStd.emergencyExitAave();
+    }
+
+    /* ─────────────────────── F-09: WITHDRAWAL COOLDOWN ─────────────── */
+
+    function test_f09_cooldown_blocks_immediate_withdraw() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVault.WithdrawalCooldown.selector,
+            block.timestamp + vaultStd.WITHDRAWAL_COOLDOWN()
+        ));
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT, user, user);
+    }
+
+    function test_f09_cooldown_blocks_immediate_redeem() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVault.WithdrawalCooldown.selector,
+            block.timestamp + vaultStd.WITHDRAWAL_COOLDOWN()
+        ));
+        vm.prank(user);
+        vaultStd.redeem(shares, user, user);
+    }
+
+    function test_f09_cooldown_allows_withdraw_after_delay() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT, user, user);
+
+        assertEq(eure.balanceOf(user), USER_BALANCE);
+    }
+
+    /// @dev Sandwich attempt: deposit just before harvest, cooldown blocks immediate exit.
+    function test_f09_sandwich_blocked_by_cooldown() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        _simulateYield(vaultStd, 35e18);
+
+        // Attacker deposits just before harvest.
+        eure.mint(address(this), DEPOSIT);
+        vm.startPrank(address(this));
+        eure.approve(address(vaultStd), DEPOSIT);
+        uint256 attackShares = vaultStd.deposit(DEPOSIT, address(this));
+        vm.stopPrank();
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        // Attacker cannot withdraw immediately — cooldown blocks the exit.
+        vm.expectRevert();
+        vm.prank(address(this));
+        vaultStd.redeem(attackShares, address(this), address(this));
+    }
+
+    /// @dev Cooldown is per-user — user2 can withdraw normally while user1 is in cooldown.
+    function test_f09_cooldown_independent_per_user() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+        _deposit(vaultStd, user2, DEPOSIT);
+
+        // user1 cooldown elapsed — can withdraw.
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT, user, user);
+
+        // user2 just deposited — cannot withdraw yet.
+        vm.expectRevert();
+        vm.prank(user2);
+        vaultStd.withdraw(DEPOSIT, user2, user2);
+    }
+
+    /// @dev Cooldown is bypassed when vault is paused (emergency exit always possible).
+    function test_f09_cooldown_bypassed_when_paused() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        // No warp — should succeed immediately because vault is paused.
+        vm.prank(user);
+        vaultStd.redeem(shares, user, user);
+
+        assertApproxEqAbs(eure.balanceOf(user), USER_BALANCE, 1e9);
+    }
+
+    /// @dev maxWithdraw and maxRedeem return 0 during cooldown.
+    function test_f09_maxWithdraw_zero_during_cooldown() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        assertEq(vaultStd.maxWithdraw(user), 0, "maxWithdraw must be 0 during cooldown");
+        assertEq(vaultStd.maxRedeem(user), 0, "maxRedeem must be 0 during cooldown");
+
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+
+        assertGt(vaultStd.maxWithdraw(user), 0, "maxWithdraw must be non-zero after cooldown");
+        assertGt(vaultStd.maxRedeem(user), 0, "maxRedeem must be non-zero after cooldown");
     }
 
     /* ─────────────────────── depositWithPermit ──────────────────────── */


### PR DESCRIPTION
## Summary

- Adds `WITHDRAWAL_COOLDOWN = 4 hours` enforced per depositor address
- `depositTimestamp[receiver]` recorded on every `deposit()`, `mint()`, `depositWithPermit()`, and `depositWithAuth()`
- `withdraw()` and `redeem()` revert with `WithdrawalCooldown(availableAt)` before the delay elapses
- `_update()` propagates `depositTimestamp` on share transfers — prevents bypass via transfer to a fresh address
- Cooldown bypassed when vault is paused — emergency exits always possible
- `maxWithdraw()` and `maxRedeem()` return 0 during cooldown (ERC-4626 compliant)

**Vector 2 (inflation attack):** `Deploy.s.sol` already provides atomic seeding within a single broadcast session — no additional change needed.

## Test plan

- [ ] `test_f09_cooldown_blocks_immediate_withdraw` — revert on immediate withdraw
- [ ] `test_f09_cooldown_blocks_immediate_redeem` — revert on immediate redeem
- [ ] `test_f09_cooldown_allows_withdraw_after_delay` — succeeds after 4 hours
- [ ] `test_f09_sandwich_blocked_by_cooldown` — attacker cannot exit after sandwiching harvest
- [ ] `test_f09_cooldown_independent_per_user` — cooldown is per-user, not global
- [ ] `test_f09_cooldown_propagated_on_transfer` — shares transfer propagates depositTimestamp
- [ ] `test_f09_cooldown_bypassed_when_paused` — emergency exit bypasses cooldown
- [ ] `test_f09_maxWithdraw_zero_during_cooldown` — maxWithdraw/maxRedeem return 0 during cooldown
- [ ] All 81 unit tests pass

Closes #3