### PR TITLE
fix(P2-F22): use type(uint256).max in emergencyExitAave

### DIFF
--- a/src/PaktolVault.sol
+++ b/src/PaktolVault.sol
@@ -603,9 +603,10 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     ///         If AAVE is fully paused (not just frozen), this call will revert.
     ///         In that case there is no on-chain remedy until AAVE unpauses.
     function emergencyExitAave() external onlyOwner nonReentrant {
-        uint256 aTokenBalance = IERC20(ATOKEN).balanceOf(address(this));
-        if (aTokenBalance == 0) return;
-        IAavePool(AAVE_POOL).withdraw(asset(), aTokenBalance, address(this));
-        emit EmergencyExitAave(aTokenBalance, block.timestamp);
+        if (IERC20(ATOKEN).balanceOf(address(this)) == 0) return;
+        // type(uint256).max lets Aave resolve the live balance server-side,
+        // removing the 1-wei race condition caused by the rebasing aToken.
+        uint256 withdrawn = IAavePool(AAVE_POOL).withdraw(asset(), type(uint256).max, address(this));
+        emit EmergencyExitAave(withdrawn, block.timestamp);
     }
 }

--- a/test/mocks/MockAavePool.sol
+++ b/test/mocks/MockAavePool.sol
@@ -85,15 +85,18 @@ contract MockAavePool {
     }
 
     /// @dev Burns aEURe from msg.sender (the vault), sends EURe from aToken to `to`.
-    ///      Supports harvest path (to = TREASURY) and user withdrawal (to = vault).
+    ///      Mirrors Aave v3: type(uint256).max resolves to caller's full aToken balance.
     function withdraw(
         address,
         uint256 amount,
         address to
     ) external returns (uint256) {
-        aToken.burn(msg.sender, amount);
-        aToken.transferUnderlying(to, amount);
-        return amount;
+        uint256 resolved = amount == type(uint256).max
+            ? aToken.balanceOf(msg.sender)
+            : amount;
+        aToken.burn(msg.sender, resolved);
+        aToken.transferUnderlying(to, resolved);
+        return resolved;
     }
 
     /// @notice Simulates interest accrual. Call eure.mint(address(pool.aToken()), amount) first.


### PR DESCRIPTION
## Summary

Fixes **F-22** — aToken rebase race condition in `emergencyExitAave()`.

The previous `balanceOf` + `withdraw(exactAmount)` pattern introduced a narrow window where the aToken rebasing liquidity index could advance by 1 wei between the read and the withdraw call, causing a revert precisely when emergency exit is most critical.

**Changes:**
- `PaktolVault.sol`: replace `withdraw(aTokenBalance, ...)` with `withdraw(type(uint256).max, ...)` — Aave v3 canonical "withdraw all" pattern, resolved server-side against the live balance at execution time
- `MockAavePool.sol`: mirror Aave v3 behaviour — `type(uint256).max` resolves to caller's full aToken balance

## Test plan

- [x] 81/81 unit tests passing
- [x] `test_emergencyExit_pullsAllFromAave` — vault holds no aTokens after exit
- [x] `test_emergencyExit_usersCanWithdraw` — users can redeem from idle EURe post-exit
- [x] `test_emergencyExit_emitsEvent` — event emits correct withdrawn amount

Closes #14