### PR TITLE
fix(P2-F21): tighten FEE_BPS constructor bound to FLOOR_BPS

### DIFF
--- a/src/PaktolVault.sol
+++ b/src/PaktolVault.sol
@@ -192,7 +192,7 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         if (aToken_ == address(0)) revert ZeroAddress();
         if (signer_ == address(0)) revert ZeroAddress();
         if (capBps_ == 0 || capBps_ > BPS_DENOMINATOR) revert CapOutOfRange(capBps_);
-        if (feeBps_ >= BPS_DENOMINATOR) revert FeeOutOfRange(feeBps_);
+        if (feeBps_ > FLOOR_BPS) revert FeeOutOfRange(feeBps_);
 
         IAavePool.ReserveData memory reserve = IAavePool(aavePool_).getReserveData(address(asset_));
         if (reserve.aTokenAddress != aToken_) revert ATokenMismatch(aToken_, reserve.aTokenAddress);

--- a/test/PaktolVault.t.sol
+++ b/test/PaktolVault.t.sol
@@ -153,6 +153,14 @@ contract PaktolVaultTest is Test {
         );
     }
 
+    function helper_deployFeeAboveFloor() external {
+        new PaktolVault(
+            IERC20(address(eure)), "x", "x", owner,
+            treasury, CAP_STD, 201, guardian, harvester,
+            address(pool), address(pool.aToken()), 0, signerAddr, false
+        );
+    }
+
     function helper_deployATokenMismatch(address wrongAToken_) external {
         new PaktolVault(
             IERC20(address(eure)), "x", "x", owner,
@@ -201,6 +209,21 @@ contract PaktolVaultTest is Test {
     function test_constructor_revert_fee100pct() public {
         vm.expectRevert(abi.encodeWithSelector(PaktolVault.FeeOutOfRange.selector, 10_000));
         this.helper_deployFee100pct();
+    }
+
+    // F-21: FEE_BPS > FLOOR_BPS causes harvest() DoS — tighten constructor bound.
+    function test_f21_constructor_revert_fee_above_floor_bps() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVault.FeeOutOfRange.selector, 201));
+        this.helper_deployFeeAboveFloor();
+    }
+
+    function test_f21_constructor_accepts_fee_at_floor_bps() public {
+        PaktolVault v = new PaktolVault(
+            IERC20(address(eure)), "x", "x", owner,
+            treasury, CAP_STD, 200, guardian, harvester,
+            address(pool), address(pool.aToken()), 0, signerAddr, false
+        );
+        assertEq(v.FEE_BPS(), 200);
     }
 
     function test_constructor_revert_aTokenMismatch() public {


### PR DESCRIPTION
## Summary

- Tightens `FEE_BPS` constructor bound from `< BPS_DENOMINATOR (10000)` to `<= FLOOR_BPS (200)`
- Prevents harvest() DoS where fee >= yield causes underflow revert
- Adds two tests: revert above floor, accept at floor

## Tests

73/73 passing (`forge test --no-match-path "*.fork.t.sol"`)

Closes #13