### PR TITLE
fix(P2-F14): enforce role separation in constructor and setters

### DIFF
--- a/src/PaktolVault.sol
+++ b/src/PaktolVault.sol
@@ -146,6 +146,7 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     error InvalidSignature();
     error SignatureExpired();
     error WithdrawalCooldown(uint256 availableAt);
+    error RolesNotSeparated();
 
     /* ─────────────────────────── CONSTRUCTOR ───────────────────────── */
 
@@ -193,6 +194,7 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         if (signer_ == address(0)) revert ZeroAddress("signer");
         if (capBps_ == 0 || capBps_ > BPS_DENOMINATOR) revert CapOutOfRange(capBps_);
         if (feeBps_ > FLOOR_BPS) revert FeeOutOfRange(feeBps_);
+        if (owner_ == guardian_ || owner_ == harvester_ || guardian_ == harvester_) revert RolesNotSeparated();
 
         IAavePool.ReserveData memory reserve = IAavePool(aavePool_).getReserveData(address(asset_));
         if (reserve.aTokenAddress != aToken_) revert ATokenMismatch(aToken_, reserve.aTokenAddress);
@@ -577,6 +579,7 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         address newGuardian_
     ) external onlyOwner {
         if (newGuardian_ == address(0)) revert ZeroAddress("newGuardian");
+        if (newGuardian_ == owner() || newGuardian_ == harvester) revert RolesNotSeparated();
         emit GuardianChanged(guardian, newGuardian_);
         guardian = newGuardian_;
     }
@@ -586,6 +589,7 @@ contract PaktolVault is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         address newHarvester_
     ) external onlyOwner {
         if (newHarvester_ == address(0)) revert ZeroAddress("newHarvester");
+        if (newHarvester_ == owner() || newHarvester_ == guardian) revert RolesNotSeparated();
         emit HarvesterChanged(harvester, newHarvester_);
         harvester = newHarvester_;
     }

--- a/test/PaktolVault.t.sol
+++ b/test/PaktolVault.t.sol
@@ -169,6 +169,30 @@ contract PaktolVaultTest is Test {
         );
     }
 
+    function helper_deployOwnerEqualsGuardian() external {
+        new PaktolVault(
+            IERC20(address(eure)), "x", "x", owner,
+            treasury, CAP_STD, FEE_STD, owner, harvester,
+            address(pool), address(pool.aToken()), 0, signerAddr, false
+        );
+    }
+
+    function helper_deployOwnerEqualsHarvester() external {
+        new PaktolVault(
+            IERC20(address(eure)), "x", "x", owner,
+            treasury, CAP_STD, FEE_STD, guardian, owner,
+            address(pool), address(pool.aToken()), 0, signerAddr, false
+        );
+    }
+
+    function helper_deployGuardianEqualsHarvester() external {
+        new PaktolVault(
+            IERC20(address(eure)), "x", "x", owner,
+            treasury, CAP_STD, FEE_STD, guardian, guardian,
+            address(pool), address(pool.aToken()), 0, signerAddr, false
+        );
+    }
+
     /* ─────────────────────── CONSTRUCTOR ────────────────────────────── */
 
     function test_constructor_immutables() public view {
@@ -224,6 +248,22 @@ contract PaktolVaultTest is Test {
             address(pool), address(pool.aToken()), 0, signerAddr, false
         );
         assertEq(v.FEE_BPS(), 200);
+    }
+
+    // F-14: role separation enforced in constructor
+    function test_f14_constructor_revert_ownerEqualsGuardian() public {
+        vm.expectRevert(PaktolVault.RolesNotSeparated.selector);
+        this.helper_deployOwnerEqualsGuardian();
+    }
+
+    function test_f14_constructor_revert_ownerEqualsHarvester() public {
+        vm.expectRevert(PaktolVault.RolesNotSeparated.selector);
+        this.helper_deployOwnerEqualsHarvester();
+    }
+
+    function test_f14_constructor_revert_guardianEqualsHarvester() public {
+        vm.expectRevert(PaktolVault.RolesNotSeparated.selector);
+        this.helper_deployGuardianEqualsHarvester();
     }
 
     function test_constructor_revert_aTokenMismatch() public {
@@ -647,6 +687,31 @@ contract PaktolVaultTest is Test {
         vm.expectRevert();
         vm.prank(user);
         vaultStd.setHarvester(makeAddr("x"));
+    }
+
+    // F-14: role separation enforced in setGuardian / setHarvester
+    function test_f14_setGuardian_revert_equalsOwner() public {
+        vm.expectRevert(PaktolVault.RolesNotSeparated.selector);
+        vm.prank(owner);
+        vaultStd.setGuardian(owner);
+    }
+
+    function test_f14_setGuardian_revert_equalsHarvester() public {
+        vm.expectRevert(PaktolVault.RolesNotSeparated.selector);
+        vm.prank(owner);
+        vaultStd.setGuardian(harvester);
+    }
+
+    function test_f14_setHarvester_revert_equalsOwner() public {
+        vm.expectRevert(PaktolVault.RolesNotSeparated.selector);
+        vm.prank(owner);
+        vaultStd.setHarvester(owner);
+    }
+
+    function test_f14_setHarvester_revert_equalsGuardian() public {
+        vm.expectRevert(PaktolVault.RolesNotSeparated.selector);
+        vm.prank(owner);
+        vaultStd.setHarvester(guardian);
     }
 
     function test_maxDeposit_returnsZero_whenPaused() public {


### PR DESCRIPTION
Closes #11

## Problem

Nothing prevented `owner == guardian`, `owner == harvester`, or `guardian == harvester` at construction time or during role updates. The multi-role security model could be silently misconfigured.

## Fix

**src/PaktolVault.sol**
- Added `error RolesNotSeparated()`
- Constructor: revert if any two of `owner_`, `guardian_`, `harvester_` are equal
- `setGuardian()`: revert if new guardian equals owner or current harvester
- `setHarvester()`: revert if new harvester equals owner or current guardian

**test/PaktolVault.t.sol**
- `test_f14_constructor_revert_ownerEqualsGuardian`
- `test_f14_constructor_revert_ownerEqualsHarvester`
- `test_f14_constructor_revert_guardianEqualsHarvester`
- `test_f14_setGuardian_revert_equalsOwner`
- `test_f14_setGuardian_revert_equalsHarvester`
- `test_f14_setHarvester_revert_equalsOwner`
- `test_f14_setHarvester_revert_equalsGuardian`

## Result

104/104 tests pass.