### PR TITLE
fix(audit): F-10 exclude donations from totalAssets via _idleBalance

### DIFF
--- a/src/PaktolVaultV2.sol
+++ b/src/PaktolVaultV2.sol
@@ -83,6 +83,9 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     mapping(address => uint256) public depositTimestamp;
     address public guardian;
     address public harvester;
+    /// @dev Tracks EURC held idle by this contract after emergencyExitByzantine().
+    ///      Explicit tracking prevents donations from inflating totalAssets() (F-10).
+    uint256 private _idleBalance;
 
     /* ───────────────────────────── EVENTS ──────────────────────────── */
 
@@ -218,11 +221,14 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
 
     /* ──────────────────────────── TOTAL ASSETS ─────────────────────── */
 
-    /// @notice Byzantine shares converted to EURC + any idle EURC held by this vault.
+    /// @notice Value of Byzantine vault shares + tracked idle EURC.
+    /// @dev    Uses _idleBalance instead of balanceOf(address(this)) to prevent donation
+    ///         inflation (F-10). _idleBalance is only set by emergencyExitByzantine() —
+    ///         direct EURC transfers to this contract are silently ignored in yield accounting.
     function totalAssets() public view override returns (uint256) {
         uint256 bzyShares = BYZANTINE_VAULT.balanceOf(address(this));
         uint256 bzyValue  = bzyShares > 0 ? BYZANTINE_VAULT.convertToAssets(bzyShares) : 0;
-        return bzyValue + IERC20(asset()).balanceOf(address(this));
+        return bzyValue + _idleBalance;
     }
 
     /* ─────────────────────── BYZANTINE ROUTING ─────────────────────── */
@@ -334,6 +340,7 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         }
         uint256 shares = super.withdraw(assets, receiver, owner_);
         _syncLastTotalAssets(-int256(assets));
+        if (_idleBalance != 0) _idleBalance = _idleBalance > assets ? _idleBalance - assets : 0;
         return shares;
     }
 
@@ -343,6 +350,7 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         }
         uint256 assets = super.redeem(shares, receiver, owner_);
         _syncLastTotalAssets(-int256(assets));
+        if (_idleBalance != 0) _idleBalance = _idleBalance > assets ? _idleBalance - assets : 0;
         return assets;
     }
 
@@ -448,6 +456,7 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         uint256 shares = BYZANTINE_VAULT.balanceOf(address(this));
         if (shares == 0) return;
         uint256 withdrawn = BYZANTINE_VAULT.redeem(shares, address(this), address(this));
+        _idleBalance         = withdrawn;
         lastTotalAssets      = totalAssets();
         lastHarvestTimestamp = block.timestamp;
         emit EmergencyExitV2(withdrawn, block.timestamp);

--- a/test/PaktolVaultV2.t.sol
+++ b/test/PaktolVaultV2.t.sol
@@ -1335,4 +1335,72 @@ contract PaktolVaultV2Test is Test {
 
         assertGt(vaultStd.totalAssets(), before);
     }
+
+    /* ─────────────────────────── F-10 tests ────────────────────────── */
+
+    /// @dev Direct EURC transfer must not inflate totalAssets() or grossYield.
+    function test_f10_donation_doesNotInflateTotalAssets() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        uint256 assetsBefore = vaultStd.totalAssets();
+
+        // Attacker donates directly to vault without going through deposit()
+        vm.prank(user2);
+        eurc.transfer(address(vaultStd), 1_000e6);
+
+        assertEq(vaultStd.totalAssets(), assetsBefore, "donation must not inflate totalAssets");
+    }
+
+    /// @dev Donation must not create artificial grossYield at harvest.
+    function test_f10_donation_doesNotInflateHarvestYield() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.warp(block.timestamp + vaultStd.MIN_HARVEST_INTERVAL() + 1);
+
+        // Harvest before donation — baseline
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 lastAssets = vaultStd.lastTotalAssets();
+
+        // Attacker donates after harvest snapshot
+        vm.prank(user2);
+        eurc.transfer(address(vaultStd), 1_000e6);
+
+        // Simulate real yield
+        mockStd.simulateYield(10e6);
+
+        vm.warp(block.timestamp + vaultStd.MIN_HARVEST_INTERVAL() + 1);
+
+        uint256 treasuryBefore = eurc.balanceOf(treasury);
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        // Treasury should only receive yield from Byzantine, not from the donation
+        uint256 harvested = eurc.balanceOf(treasury) - treasuryBefore;
+        assertLt(harvested, 1_000e6, "donation must not reach treasury via harvest");
+        assertApproxEqAbs(vaultStd.lastTotalAssets(), lastAssets + 10e6 - harvested, 1e3, "lastTotalAssets must not include donation");
+    }
+
+    /// @dev After emergency exit, idle EURC must still be counted in totalAssets
+    ///      so users can fully redeem their shares.
+    function test_f10_emergencyExit_idleStillCountedInTotalAssets() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        // totalAssets must equal DEPOSIT (all funds now idle)
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT, 1e3);
+
+        // User can fully redeem
+        uint256 balBefore = eurc.balanceOf(user);
+        vm.prank(user);
+        vaultStd.redeem(shares, user, user);
+        assertApproxEqAbs(eurc.balanceOf(user) - balBefore, DEPOSIT, 1e3);
+
+        // _idleBalance drains to zero after full redemption
+        assertEq(vaultStd.totalAssets(), 0);
+    }
 }


### PR DESCRIPTION
## Summary

- Replaces `balanceOf(address(this))` in `totalAssets()` with a tracked `_idleBalance` variable
- `_idleBalance` is only set by `emergencyExitByzantine()` — direct EURC transfers to the contract are excluded from yield accounting
- Emergency exit path unchanged: idle EURC is still counted correctly for user redemptions

## Changes

- `src/PaktolVaultV2.sol`: add `_idleBalance` storage var, update `totalAssets()`, `emergencyExitByzantine()`, `withdraw()`, `redeem()`
- `test/PaktolVaultV2.t.sol`: 3 new tests (`test_f10_*`)

## Tests

104/104 passing.

Closes #12