### PR TITLE
feat: PaktolVaultV2 — Base Mainnet deploy (Vault A + B)

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,8 @@
+{
+  "lib/erc4626-tests": {
+    "tag": {
+      "name": "v0.1.1",
+      "rev": "232ff9ba8194e406967f52ecc5cb52ed764209e9"
+    }
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -35,6 +35,7 @@ mainnet = "${MAINNET_RPC_URL}"
 sepolia = "${SEPOLIA_RPC_URL}"
 arbitrum = "${ARBITRUM_RPC_URL}"
 base = "${BASE_RPC_URL}"
+base_sepolia = "${BASE_SEPOLIA_RPC_URL}"
 gnosis = "${GNOSIS_RPC_URL}"
 
 # Etherscan API keys
@@ -43,3 +44,4 @@ mainnet = { key = "${ETHERSCAN_API_KEY}" }
 sepolia = { key = "${ETHERSCAN_API_KEY}" }
 arbitrum = { key = "${ARBISCAN_API_KEY}" }
 base = { key = "${BASESCAN_API_KEY}" }
+base_sepolia = { key = "${BASESCAN_API_KEY}", chain = 84532 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -43,5 +43,5 @@ gnosis = "${GNOSIS_RPC_URL}"
 mainnet = { key = "${ETHERSCAN_API_KEY}" }
 sepolia = { key = "${ETHERSCAN_API_KEY}" }
 arbitrum = { key = "${ARBISCAN_API_KEY}" }
-base = { key = "${BASESCAN_API_KEY}" }
+base = { key = "${BASESCAN_API_KEY}", chain = 8453 }
 base_sepolia = { key = "${BASESCAN_API_KEY}", chain = 84532 }

--- a/script/DeployBaseV2.s.sol
+++ b/script/DeployBaseV2.s.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+import "../src/PaktolVaultV2.sol";
+
+/// @dev Deploy PaktolVaultV2 on Base Mainnet against a Byzantine EUR vault.
+///
+///      Required env vars:
+///        DEPLOYER_PRIVATE_KEY   hex private key of the deployer
+///        OWNER                  multisig / EOA that will own the vault
+///        TREASURY               address that receives fee shares
+///        GUARDIAN               address allowed to pause
+///        HARVESTER              address allowed to call harvest()
+///        CAP_BPS                yield cap in bps (e.g. 500 = 5%)
+///        FEE_BPS                performance fee in bps (e.g. 50 = 0.5%)
+///        VAULT_NAME             ERC-20 name  (e.g. "Paktol Standard EURC")
+///        VAULT_SYMBOL           ERC-20 symbol (e.g. "pkEURC-S")
+///        BYZANTINE_VAULT_ADDR   which Byzantine vault to use (see constants below)
+///      Optional:
+///        MAX_TVL                max TVL in EURC raw units (0 = unlimited)
+///        PREMIUM_THRESHOLD      points threshold for premium display (0 = none)
+///        REQUIRES_AUTH          true if vault requires grantPremiumAccess (default false)
+///
+///      Byzantine vault options (Base Mainnet):
+///        SANDBOX  (tests only): 0x7aA6B0aff73E3E0416CdfCD64F51E5cFa910ad01
+///        PROD standard:         0x061b3aff8e21a9d194ce43cEfc20A0eFf122Ec69
+///        PROD insured:          0x3d6A627d992f717e11353F275a7970AD4af073AC
+///
+///      IMPORTANT: after deploy, ask Byzantine to whitelist your vault address so it
+///      can deposit. Without whitelist, _depositToByzantine() will revert.
+
+// ── Immutable addresses on Base Mainnet ──────────────────────────────────────
+address constant EURC_BASE = 0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42;
+
+// Byzantine EUR vault addresses — pick one via BYZANTINE_VAULT_ADDR env var
+address constant BYZ_SANDBOX  = 0x7aA6B0aff73E3E0416CdfCD64F51E5cFa910ad01; // test only
+address constant BYZ_STANDARD = 0x061b3aff8e21a9d194ce43cEfc20A0eFf122Ec69; // prod
+address constant BYZ_INSURED  = 0x3d6A627d992f717e11353F275a7970AD4af073AC; // prod (insured)
+
+contract DeployBaseV2 is Script {
+    function run() external {
+        uint256 deployerKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+
+        address owner     = vm.envAddress("OWNER");
+        address treasury  = vm.envAddress("TREASURY");
+        address guardian  = vm.envAddress("GUARDIAN");
+        address harvester = vm.envAddress("HARVESTER");
+
+        uint256 capBps           = vm.envUint("CAP_BPS");
+        uint256 feeBps           = vm.envUint("FEE_BPS");
+        uint256 maxTvl           = vm.envOr("MAX_TVL", uint256(0));
+        uint256 premiumThreshold = vm.envOr("PREMIUM_THRESHOLD", uint256(0));
+        bool    requiresAuth     = vm.envOr("REQUIRES_AUTH", false);
+
+        string memory name   = vm.envString("VAULT_NAME");
+        string memory symbol = vm.envString("VAULT_SYMBOL");
+
+        address byzantineVault = vm.envAddress("BYZANTINE_VAULT_ADDR");
+
+        // Sanity check: Byzantine vault must expose EURC as asset.
+        require(
+            IERC4626(byzantineVault).asset() == EURC_BASE,
+            "Byzantine vault asset mismatch - wrong address?"
+        );
+
+        address deployer = vm.addr(deployerKey);
+
+        vm.startBroadcast(deployerKey);
+
+        // Deploy with deployer as initial owner so it can seed dead shares.
+        // Ownership is transferred to the multisig right after.
+        PaktolVaultV2 vault = new PaktolVaultV2(
+            IERC20(EURC_BASE),
+            name,
+            symbol,
+            deployer,
+            treasury,
+            capBps,
+            feeBps,
+            guardian,
+            harvester,
+            byzantineVault,
+            maxTvl,
+            premiumThreshold,
+            requiresAuth
+        );
+
+        // Initiate 2-step ownership transfer to the real owner (multisig).
+        vault.transferOwnership(owner);
+
+        vm.stopBroadcast();
+
+        console.log("=== DEPLOYMENT COMPLETE ===");
+        console.log("PaktolVaultV2  :", address(vault));
+        console.log("EURC           :", EURC_BASE);
+        console.log("Byzantine vault:", byzantineVault);
+        console.log("Owner          :", owner);
+        console.log("CAP_BPS        :", capBps);
+        console.log("FEE_BPS        :", feeBps);
+        console.log("REQUIRES_AUTH  :", requiresAuth);
+
+        // Post-deploy invariant checks.
+        require(vault.owner()           == deployer,                     "owner mismatch");
+        require(vault.pendingOwner()    == owner,                        "pendingOwner mismatch");
+        require(vault.TREASURY()        == treasury,                     "treasury mismatch");
+        require(address(vault.asset())  == EURC_BASE,                    "asset mismatch");
+        require(vault.BYZANTINE_VAULT() == IERC4626(byzantineVault),     "byzantine mismatch");
+
+        console.log("");
+        console.log("IMPORTANT: Call acceptOwnership() from:", owner);
+
+        console.log("");
+        console.log("Next step: seed dead shares.");
+        console.log("Run: forge script script/DeployBaseV2.s.sol:SeedV2Base --broadcast --rpc-url base");
+        console.log("     with VAULT_ADDRESS=", address(vault));
+    }
+}
+
+/// @dev Seed 1 MIN_DEPOSIT worth of shares to address(0xdEaD) to prevent inflation attacks.
+///      Must be run by the owner (who holds EURC and approved the vault).
+contract SeedV2Base is Script {
+    function run() external {
+        uint256 ownerKey  = vm.envUint("OWNER_PRIVATE_KEY");
+        address vaultAddr = vm.envAddress("VAULT_ADDRESS");
+
+        PaktolVaultV2 vault = PaktolVaultV2(vaultAddr);
+        uint256 seedAmount  = vault.MIN_DEPOSIT();
+        address asset       = vault.asset();
+
+        console.log("Seeding", seedAmount, "EURC (raw) into vault...");
+
+        vm.startBroadcast(ownerKey);
+        IERC20(asset).approve(vaultAddr, seedAmount);
+        vault.deposit(seedAmount, address(0xdEaD));
+        vm.stopBroadcast();
+
+        require(vault.totalSupply() > 0, "Seed failed");
+        console.log("Dead shares seeded. lastTotalAssets:", vault.lastTotalAssets());
+        console.log("Vault is ready for deposits.");
+    }
+}

--- a/script/DeploySepoliaV2.s.sol
+++ b/script/DeploySepoliaV2.s.sol
@@ -14,11 +14,11 @@ contract DeploySepoliaV2 is Script {
         address treasury  = vm.envAddress("TREASURY");
         address guardian  = vm.envAddress("GUARDIAN");
         address harvester = vm.envAddress("HARVESTER");
-        address signer    = vm.envAddress("SIGNER");
-        uint256 capBps    = vm.envUint("CAP_BPS");
-        uint256 feeBps    = vm.envUint("FEE_BPS");
-        uint256 maxTvl    = vm.envOr("MAX_TVL", uint256(0));
-        bool requiresAuth = vm.envOr("REQUIRES_AUTH", false);
+        uint256 capBps           = vm.envUint("CAP_BPS");
+        uint256 feeBps           = vm.envUint("FEE_BPS");
+        uint256 maxTvl           = vm.envOr("MAX_TVL", uint256(0));
+        uint256 premiumThreshold = vm.envOr("PREMIUM_THRESHOLD", uint256(0));
+        bool requiresAuth        = vm.envOr("REQUIRES_AUTH", false);
         string memory name   = vm.envString("VAULT_NAME");
         string memory symbol = vm.envString("VAULT_SYMBOL");
 
@@ -42,7 +42,7 @@ contract DeploySepoliaV2 is Script {
             harvester,
             address(byzantineVault),
             maxTvl,
-            signer,
+            premiumThreshold,
             requiresAuth
         );
 

--- a/script/DeploySepoliaV2.s.sol
+++ b/script/DeploySepoliaV2.s.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+import "../src/PaktolVaultV2.sol";
+import "../test/mocks/MockEURC.sol";
+import "../test/mocks/MockByzantineVault.sol";
+
+contract DeploySepoliaV2 is Script {
+    function run() external {
+        uint256 deployerKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+
+        address owner     = vm.envAddress("OWNER");
+        address treasury  = vm.envAddress("TREASURY");
+        address guardian  = vm.envAddress("GUARDIAN");
+        address harvester = vm.envAddress("HARVESTER");
+        address signer    = vm.envAddress("SIGNER");
+        uint256 capBps    = vm.envUint("CAP_BPS");
+        uint256 feeBps    = vm.envUint("FEE_BPS");
+        uint256 maxTvl    = vm.envOr("MAX_TVL", uint256(0));
+        bool requiresAuth = vm.envOr("REQUIRES_AUTH", false);
+        string memory name   = vm.envString("VAULT_NAME");
+        string memory symbol = vm.envString("VAULT_SYMBOL");
+
+        vm.startBroadcast(deployerKey);
+
+        MockEURC eurc = new MockEURC();
+        MockByzantineVault byzantineVault = new MockByzantineVault(IERC20(address(eurc)));
+
+        console.log("MockEURC          deployed at:", address(eurc));
+        console.log("MockByzantineVault deployed at:", address(byzantineVault));
+
+        PaktolVaultV2 vault = new PaktolVaultV2(
+            IERC20(address(eurc)),
+            name,
+            symbol,
+            owner,
+            treasury,
+            capBps,
+            feeBps,
+            guardian,
+            harvester,
+            address(byzantineVault),
+            maxTvl,
+            signer,
+            requiresAuth
+        );
+
+        console.log("PaktolVaultV2     deployed at:", address(vault));
+        console.log("Owner                        :", owner);
+        console.log("CAP_BPS                      :", capBps);
+        console.log("FEE_BPS                      :", feeBps);
+        console.log("REQUIRES_AUTH                :", requiresAuth);
+
+        vm.stopBroadcast();
+
+        require(vault.owner()          == owner,                  "Owner mismatch");
+        require(vault.TREASURY()       == treasury,               "Treasury mismatch");
+        require(vault.BYZANTINE_VAULT() == IERC4626(address(byzantineVault)), "ByzantineVault mismatch");
+
+        console.log("");
+        console.log("=== DEPLOYMENT COMPLETE ===");
+        console.log("Next: seed dead shares via SeedV2 contract.");
+        if (owner != vm.addr(deployerKey)) {
+            console.log("IMPORTANT: owner != deployer - call acceptOwnership() from:", owner);
+        }
+    }
+}
+
+contract SeedV2 is Script {
+    function run() external {
+        uint256 ownerKey  = vm.envUint("OWNER_PRIVATE_KEY");
+        address vaultAddr = vm.envAddress("VAULT_ADDRESS");
+
+        PaktolVaultV2 vault = PaktolVaultV2(vaultAddr);
+        uint256 seedAmount  = vault.MIN_DEPOSIT();
+        address asset       = vault.asset();
+
+        vm.startBroadcast(ownerKey);
+
+        IERC20(asset).approve(vaultAddr, seedAmount);
+        vault.deposit(seedAmount, address(0xdEaD));
+
+        vm.stopBroadcast();
+
+        require(vault.totalSupply() > 0, "Seed failed: no shares minted");
+        console.log("Dead shares seeded. Vault ready.");
+        console.log("lastTotalAssets:", vault.lastTotalAssets());
+    }
+}

--- a/src/PaktolVaultV2.sol
+++ b/src/PaktolVaultV2.sol
@@ -285,6 +285,10 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         shares = _executeDeposit(accepted, receiver);
     }
 
+    /// @dev F-13: permit is only called when allowance is insufficient.
+    ///      If permit fails (nonce unchanged), revert — prevents a third party from
+    ///      triggering a deposit against a residual pre-existing allowance via an
+    ///      invalid/expired permit signature.
     function depositWithPermit(
         uint256 assets,
         address receiver,
@@ -293,8 +297,11 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     ) external whenNotPaused nonReentrant returns (uint256) {
         if (REQUIRES_AUTH) revert UseDepositWithAuth();
         if (assets < MIN_DEPOSIT) revert DepositTooSmall(assets, MIN_DEPOSIT);
-        try IERC20Permit(asset()).permit(msg.sender, address(this), assets, deadline, v, r, s) { } catch { }
-        if (IERC20(asset()).allowance(msg.sender, address(this)) < assets) revert InsufficientAllowance();
+        if (IERC20(asset()).allowance(msg.sender, address(this)) < assets) {
+            uint256 nonceBefore = IERC20Permit(asset()).nonces(msg.sender);
+            try IERC20Permit(asset()).permit(msg.sender, address(this), assets, deadline, v, r, s) { } catch { }
+            if (IERC20Permit(asset()).nonces(msg.sender) == nonceBefore) revert InsufficientAllowance();
+        }
         return _executeDeposit(assets, receiver);
     }
 

--- a/src/PaktolVaultV2.sol
+++ b/src/PaktolVaultV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 import "@openzeppelin/contracts/interfaces/IERC4626.sol";
@@ -87,6 +87,7 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     /* ───────────────────────────── EVENTS ──────────────────────────── */
 
     event Harvested(uint256 grossYield, uint256 toTreasury, uint256 toUsers, uint256 timestamp);
+    event HarvestSkipped(uint256 totalAssets, uint256 timestamp);
     event GuardianChanged(address indexed oldGuardian, address indexed newGuardian);
     event HarvesterChanged(address indexed oldHarvester, address indexed newHarvester);
     event EmergencyExitV2(uint256 amount, uint256 timestamp);
@@ -386,6 +387,7 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
 
         if (current <= lastTotalAssets) {
             lastTotalAssets = current;
+            emit HarvestSkipped(current, block.timestamp);
             return;
         }
 

--- a/src/PaktolVaultV2.sol
+++ b/src/PaktolVaultV2.sol
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+/// @title PaktolVaultV2
+/// @author P.LECROSNIER
+/// @notice ERC-4626 vault routing EURC deposits into Byzantine Finance VaultV2 on Base.
+///         Identical fee/harvest logic to PaktolVault — only the yield source changes
+///         (Byzantine VaultV2 Morpho-backed ERC-4626 instead of AAVE v3).
+///
+///         Standard (FEE_BPS = 50, CAP_BPS = 350):
+///           - 0.5% annual AUM fee on total capital, pro-rated per harvest.
+///           - Fee floor at 2% APY: below that, fee scales down with yield.
+///           - User net yield capped at 3.5% per year.
+///           - AUM fee + surplus above cap → treasury.
+///
+///         Premium — points tier or legal entity (FEE_BPS = 50, CAP_BPS = 500):
+///           - 0.5% annual AUM fee on total capital, pro-rated per harvest.
+///           - Fee floor at 2% APY: below that, fee scales down with yield.
+///           - User net yield capped at 5% per year.
+///           - AUM fee + surplus above cap → treasury.
+///           - Deposits gated via depositWithAuth() — backend signs when tier is active.
+///
+///         Harvest formula (unified, covers both plans):
+///           maxAumFee  = lastTotalAssets × FEE_BPS × elapsed / (BPS_DENOMINATOR × SECONDS_PER_YEAR)
+///           flooredFee = grossYield × FEE_BPS / FLOOR_BPS
+///           aumFee     = min(maxAumFee, flooredFee)
+///           remaining  = grossYield − aumFee
+///           toUsers    = min(remaining, maxNetYield)
+///           toTreasury = grossYield − toUsers
+///
+contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    /* ─────────────────────────── CONSTANTS ─────────────────────────── */
+
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+    uint256 public constant SECONDS_PER_YEAR = 365 days;
+
+    bytes32 public constant DEPOSIT_AUTH_TYPEHASH =
+        keccak256("DepositAuth(address sender,uint256 assets,address receiver,uint256 deadline,uint256 nonce)");
+
+    /// @notice APY floor below which the AUM fee is pro-rated down (200 = 2%).
+    uint256 public constant FLOOR_BPS = 200;
+
+    /// @notice Minimum deposit. EURC has 6 decimals: 1e3 = 0.001 EURC.
+    uint256 public constant MIN_DEPOSIT = 1e3;
+
+    uint256 public constant MIN_HARVEST_INTERVAL = 1 days;
+
+    uint256 public constant WITHDRAWAL_COOLDOWN = 4 hours;
+
+    /* ─────────────────────────── IMMUTABLES ────────────────────────── */
+
+    uint256 public immutable CAP_BPS;
+    uint256 public immutable FEE_BPS;
+    address public immutable TREASURY;
+
+    /// @notice Byzantine Finance VaultV2 (ERC-4626, Morpho-backed).
+    ///         Must accept EURC as its underlying asset.
+    ///         Paktol's deployer address must be whitelisted on Byzantine's GateWhitelist
+    ///         before any deposit can succeed.
+    IERC4626 public immutable BYZANTINE_VAULT;
+
+    uint256 public immutable MAX_TVL;
+    address public immutable SIGNER;
+    bool public immutable REQUIRES_AUTH;
+    bytes32 public immutable DOMAIN_SEPARATOR;
+
+    /* ───────────────────────────── STORAGE ─────────────────────────── */
+
+    uint256 public lastTotalAssets;
+    mapping(address => uint256) public nonces;
+    uint256 public lastHarvestTimestamp;
+    mapping(address => uint256) public depositTimestamp;
+    address public guardian;
+    address public harvester;
+
+    /* ───────────────────────────── EVENTS ──────────────────────────── */
+
+    event Harvested(uint256 grossYield, uint256 toTreasury, uint256 toUsers, uint256 timestamp);
+    event GuardianChanged(address indexed oldGuardian, address indexed newGuardian);
+    event HarvesterChanged(address indexed oldHarvester, address indexed newHarvester);
+    event EmergencyExitV2(uint256 amount, uint256 timestamp);
+
+    /* ───────────────────────────── ERRORS ──────────────────────────── */
+
+    error ZeroAddress(string param);
+    error ByzantineVaultAssetMismatch(address byzantineAsset, address expected);
+    error CapOutOfRange(uint256 provided);
+    error FeeOutOfRange(uint256 provided);
+    error NotGuardian();
+    error NotHarvester();
+    error DepositTooSmall(uint256 assets, uint256 minimum);
+    error TvlCapExceeded(uint256 current, uint256 cap);
+    error HarvestTooFrequent(uint256 elapsed, uint256 minimum);
+    error InsufficientAllowance();
+    error UseDepositWithAuth();
+    error InvalidSignature();
+    error SignatureExpired();
+    error WithdrawalCooldown(uint256 availableAt);
+    error RolesNotSeparated();
+
+    /* ─────────────────────────── CONSTRUCTOR ───────────────────────── */
+
+    /// @param asset_          EURC token address (6 decimals).
+    /// @param name_           Share token name.
+    /// @param symbol_         Share token symbol.
+    /// @param owner_          Initial owner — multisig in production.
+    /// @param treasury_       Receives fee + yield surplus. Cannot be address(0).
+    /// @param capBps_         Annual net yield cap in bps. Range: 1–10_000.
+    /// @param feeBps_         Fixed fee on gross yield in bps. 50 = Standard, 0 = Paktol.
+    /// @param guardian_       Emergency pause address. Cannot be address(0).
+    /// @param harvester_      Keeper bot allowed to call harvest(). Cannot be address(0).
+    /// @param byzantineVault_ Byzantine Finance VaultV2 address. Must accept EURC.
+    /// @param maxTvl_         Maximum total assets. 0 = uncapped.
+    /// @param signer_         Backend wallet that signs depositWithAuth. Cannot be address(0).
+    /// @param requiresAuth_   If true, only depositWithAuth() is accepted.
+    constructor(
+        IERC20  asset_,
+        string memory name_,
+        string memory symbol_,
+        address owner_,
+        address treasury_,
+        uint256 capBps_,
+        uint256 feeBps_,
+        address guardian_,
+        address harvester_,
+        address byzantineVault_,
+        uint256 maxTvl_,
+        address signer_,
+        bool    requiresAuth_
+    ) ERC4626(asset_) ERC20(name_, symbol_) Ownable(owner_) {
+        if (address(asset_) == address(0)) revert ZeroAddress("asset");
+        if (treasury_       == address(0)) revert ZeroAddress("treasury");
+        if (guardian_       == address(0)) revert ZeroAddress("guardian");
+        if (harvester_      == address(0)) revert ZeroAddress("harvester");
+        if (byzantineVault_ == address(0)) revert ZeroAddress("byzantineVault");
+        if (signer_         == address(0)) revert ZeroAddress("signer");
+        if (capBps_ == 0 || capBps_ > BPS_DENOMINATOR) revert CapOutOfRange(capBps_);
+        if (feeBps_ > FLOOR_BPS) revert FeeOutOfRange(feeBps_);
+        if (owner_ == guardian_ || owner_ == harvester_ || guardian_ == harvester_) revert RolesNotSeparated();
+
+        address byzantineAsset = IERC4626(byzantineVault_).asset();
+        if (byzantineAsset != address(asset_)) revert ByzantineVaultAssetMismatch(byzantineAsset, address(asset_));
+
+        TREASURY       = treasury_;
+        CAP_BPS        = capBps_;
+        FEE_BPS        = feeBps_;
+        guardian       = guardian_;
+        harvester      = harvester_;
+        BYZANTINE_VAULT = IERC4626(byzantineVault_);
+        MAX_TVL        = maxTvl_;
+        SIGNER         = signer_;
+        REQUIRES_AUTH  = requiresAuth_;
+
+        DOMAIN_SEPARATOR = keccak256(abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256(bytes(name_)),
+            keccak256("1"),
+            block.chainid,
+            address(this)
+        ));
+
+        lastHarvestTimestamp = block.timestamp;
+    }
+
+    /* ───────────────────────── VIRTUAL SHARES ──────────────────────── */
+
+    function _decimalsOffset() internal pure override returns (uint8) {
+        return 3;
+    }
+
+    /* ──────────────────────── ERC-4626 OVERRIDES ───────────────────── */
+
+    function maxDeposit(address) public view override returns (uint256) {
+        if (paused()) return 0;
+        if (MAX_TVL == 0) return type(uint256).max;
+        uint256 current = totalAssets();
+        return current >= MAX_TVL ? 0 : MAX_TVL - current;
+    }
+
+    function maxMint(address receiver) public view override returns (uint256) {
+        uint256 maxDep = maxDeposit(receiver);
+        if (maxDep == type(uint256).max) return type(uint256).max;
+        return previewDeposit(maxDep);
+    }
+
+    /// @notice Returns 0 within WITHDRAWAL_COOLDOWN window (vault not paused).
+    ///         Bounded by Byzantine's available liquidity (Morpho redemption queue).
+    function maxWithdraw(address owner_) public view override returns (uint256) {
+        if (!paused() && block.timestamp < depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN) return 0;
+        uint256 userAssets = convertToAssets(balanceOf(owner_));
+        uint256 idle       = IERC20(asset()).balanceOf(address(this));
+        uint256 liquid     = idle + BYZANTINE_VAULT.maxWithdraw(address(this));
+        return userAssets < liquid ? userAssets : liquid;
+    }
+
+    /// @notice Returns 0 within WITHDRAWAL_COOLDOWN window (vault not paused).
+    function maxRedeem(address owner_) public view override returns (uint256) {
+        if (!paused() && block.timestamp < depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN) return 0;
+        uint256 userShares = balanceOf(owner_);
+        uint256 idle       = IERC20(asset()).balanceOf(address(this));
+        uint256 liquid     = idle + BYZANTINE_VAULT.maxWithdraw(address(this));
+        uint256 userAssets = convertToAssets(userShares);
+        if (userAssets <= liquid) return userShares;
+        return convertToShares(liquid);
+    }
+
+    /* ──────────────────────────── TOTAL ASSETS ─────────────────────── */
+
+    /// @notice Byzantine shares converted to EURC + any idle EURC held by this vault.
+    function totalAssets() public view override returns (uint256) {
+        uint256 bzyShares = BYZANTINE_VAULT.balanceOf(address(this));
+        uint256 bzyValue  = bzyShares > 0 ? BYZANTINE_VAULT.convertToAssets(bzyShares) : 0;
+        return bzyValue + IERC20(asset()).balanceOf(address(this));
+    }
+
+    /* ─────────────────────── BYZANTINE ROUTING ─────────────────────── */
+
+    /// @dev Pushes all idle EURC into Byzantine VaultV2. Called after every deposit/mint.
+    function _depositToByzantine() internal {
+        uint256 amount = IERC20(asset()).balanceOf(address(this));
+        if (amount == 0) return;
+        IERC20(asset()).forceApprove(address(BYZANTINE_VAULT), amount);
+        BYZANTINE_VAULT.deposit(amount, address(this));
+    }
+
+    /// @dev Pulls EURC from Byzantine. Uses idle balance first, then withdraws remainder.
+    function _withdrawFromByzantine(uint256 amount, address to) internal {
+        uint256 idle   = IERC20(asset()).balanceOf(address(this));
+        uint256 needed = idle >= amount ? 0 : amount - idle;
+        if (needed > 0) {
+            BYZANTINE_VAULT.withdraw(needed, address(this), address(this));
+        }
+        if (to != address(this)) {
+            IERC20(asset()).safeTransfer(to, amount);
+        }
+    }
+
+    /* ──────────────────────── DEPOSIT / WITHDRAW ───────────────────── */
+
+    function _syncLastTotalAssets(int256 delta) internal {
+        if (delta >= 0) {
+            lastTotalAssets += uint256(delta);
+        } else {
+            uint256 decrease = uint256(-delta);
+            lastTotalAssets = lastTotalAssets > decrease ? lastTotalAssets - decrease : 0;
+        }
+    }
+
+    function _executeDeposit(uint256 assets, address receiver) internal returns (uint256) {
+        if (assets < MIN_DEPOSIT) revert DepositTooSmall(assets, MIN_DEPOSIT);
+        uint256 current = totalAssets();
+        if (MAX_TVL != 0 && current + assets > MAX_TVL) revert TvlCapExceeded(current, MAX_TVL);
+        uint256 shares = super.deposit(assets, receiver);
+        _depositToByzantine();
+        _syncLastTotalAssets(int256(assets));
+        depositTimestamp[receiver] = block.timestamp;
+        return shares;
+    }
+
+    function deposit(uint256 assets, address receiver) public override whenNotPaused nonReentrant returns (uint256) {
+        if (REQUIRES_AUTH) revert UseDepositWithAuth();
+        return _executeDeposit(assets, receiver);
+    }
+
+    function depositUpToCap(
+        uint256 assets,
+        address receiver
+    ) external whenNotPaused nonReentrant returns (uint256 accepted, uint256 shares) {
+        if (REQUIRES_AUTH) revert UseDepositWithAuth();
+        uint256 remaining = maxDeposit(receiver);
+        if (remaining == 0) return (0, 0);
+        accepted = assets > remaining ? remaining : assets;
+        shares = _executeDeposit(accepted, receiver);
+    }
+
+    function depositWithPermit(
+        uint256 assets,
+        address receiver,
+        uint256 deadline,
+        uint8 v, bytes32 r, bytes32 s
+    ) external whenNotPaused nonReentrant returns (uint256) {
+        if (REQUIRES_AUTH) revert UseDepositWithAuth();
+        if (assets < MIN_DEPOSIT) revert DepositTooSmall(assets, MIN_DEPOSIT);
+        try IERC20Permit(asset()).permit(msg.sender, address(this), assets, deadline, v, r, s) { } catch { }
+        if (IERC20(asset()).allowance(msg.sender, address(this)) < assets) revert InsufficientAllowance();
+        return _executeDeposit(assets, receiver);
+    }
+
+    function depositWithAuth(
+        uint256 assets,
+        address receiver,
+        uint256 deadline,
+        bytes calldata sig
+    ) external whenNotPaused nonReentrant returns (uint256) {
+        if (block.timestamp > deadline) revert SignatureExpired();
+        bytes32 structHash = keccak256(abi.encode(
+            DEPOSIT_AUTH_TYPEHASH,
+            msg.sender, assets, receiver, deadline,
+            nonces[msg.sender]++
+        ));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash));
+        if (ECDSA.recover(digest, sig) != SIGNER) revert InvalidSignature();
+        return _executeDeposit(assets, receiver);
+    }
+
+    function mint(uint256 shares, address receiver) public override whenNotPaused nonReentrant returns (uint256) {
+        if (REQUIRES_AUTH) revert UseDepositWithAuth();
+        uint256 assets = previewMint(shares);
+        if (assets < MIN_DEPOSIT) revert DepositTooSmall(assets, MIN_DEPOSIT);
+        uint256 current = totalAssets();
+        if (MAX_TVL != 0 && current + assets > MAX_TVL) revert TvlCapExceeded(current, MAX_TVL);
+        uint256 assetsUsed = super.mint(shares, receiver);
+        _depositToByzantine();
+        _syncLastTotalAssets(int256(assetsUsed));
+        depositTimestamp[receiver] = block.timestamp;
+        return assetsUsed;
+    }
+
+    function withdraw(uint256 assets, address receiver, address owner_) public override nonReentrant returns (uint256) {
+        if (!paused() && block.timestamp < depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN) {
+            revert WithdrawalCooldown(depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN);
+        }
+        uint256 shares = super.withdraw(assets, receiver, owner_);
+        _syncLastTotalAssets(-int256(assets));
+        return shares;
+    }
+
+    function redeem(uint256 shares, address receiver, address owner_) public override nonReentrant returns (uint256) {
+        if (!paused() && block.timestamp < depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN) {
+            revert WithdrawalCooldown(depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN);
+        }
+        uint256 assets = super.redeem(shares, receiver, owner_);
+        _syncLastTotalAssets(-int256(assets));
+        return assets;
+    }
+
+    function _update(address from, address to, uint256 amount) internal override {
+        super._update(from, to, amount);
+        if (from != address(0) && to != address(0)) {
+            if (depositTimestamp[from] > depositTimestamp[to]) {
+                depositTimestamp[to] = depositTimestamp[from];
+            }
+        }
+    }
+
+    /// @dev CEI: shares burned → emit → pull from Byzantine → transfer to receiver.
+    function _withdraw(
+        address caller,
+        address receiver,
+        address owner_,
+        uint256 assets,
+        uint256 shares
+    ) internal override {
+        if (caller != owner_) _spendAllowance(owner_, caller, shares);
+        _burn(owner_, shares);
+        emit Withdraw(caller, receiver, owner_, assets, shares);
+        uint256 idle = IERC20(asset()).balanceOf(address(this));
+        if (idle < assets) {
+            BYZANTINE_VAULT.withdraw(assets - idle, address(this), address(this));
+        }
+        IERC20(asset()).safeTransfer(receiver, assets);
+    }
+
+    /* ───────────────────────────── HARVEST ─────────────────────────── */
+
+    /// @notice Collects yield since last harvest and routes it per plan rules.
+    ///         Callable by owner or harvester.
+    function harvest() external nonReentrant {
+        if (msg.sender != owner() && msg.sender != harvester) revert NotHarvester();
+
+        uint256 elapsed = block.timestamp - lastHarvestTimestamp;
+        if (elapsed < MIN_HARVEST_INTERVAL) revert HarvestTooFrequent(elapsed, MIN_HARVEST_INTERVAL);
+
+        uint256 current = totalAssets();
+
+        if (current <= lastTotalAssets) {
+            lastTotalAssets = current;
+            return;
+        }
+
+        uint256 grossYield = current - lastTotalAssets;
+
+        uint256 maxAumFee  = (lastTotalAssets * FEE_BPS * elapsed) / (BPS_DENOMINATOR * SECONDS_PER_YEAR);
+        uint256 flooredFee = (grossYield * FEE_BPS) / FLOOR_BPS;
+        uint256 aumFee     = maxAumFee < flooredFee ? maxAumFee : flooredFee;
+
+        uint256 remaining   = grossYield - aumFee;
+        uint256 maxNetYield = (lastTotalAssets * CAP_BPS * elapsed) / (BPS_DENOMINATOR * SECONDS_PER_YEAR);
+        uint256 toUsers     = remaining < maxNetYield ? remaining : maxNetYield;
+        uint256 toTreasury  = grossYield - toUsers;
+
+        lastTotalAssets      = current - toTreasury;
+        lastHarvestTimestamp = block.timestamp;
+
+        emit Harvested(grossYield, toTreasury, toUsers, block.timestamp);
+
+        if (toTreasury > 0) {
+            _withdrawFromByzantine(toTreasury, TREASURY);
+        }
+    }
+
+    /* ───────────────────────────── GUARDIAN ────────────────────────── */
+
+    function setGuardian(address newGuardian_) external onlyOwner {
+        if (newGuardian_ == address(0)) revert ZeroAddress("newGuardian");
+        if (newGuardian_ == owner() || newGuardian_ == harvester) revert RolesNotSeparated();
+        emit GuardianChanged(guardian, newGuardian_);
+        guardian = newGuardian_;
+    }
+
+    function setHarvester(address newHarvester_) external onlyOwner {
+        if (newHarvester_ == address(0)) revert ZeroAddress("newHarvester");
+        if (newHarvester_ == owner() || newHarvester_ == guardian) revert RolesNotSeparated();
+        emit HarvesterChanged(harvester, newHarvester_);
+        harvester = newHarvester_;
+    }
+
+    /* ──────────────────────────────  PAUSE  ────────────────────────── */
+
+    function pause() external {
+        if (msg.sender != owner() && msg.sender != guardian) revert NotGuardian();
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    /* ────────────────────────── EMERGENCY EXIT ──────────────────────── */
+
+    /// @notice Redeems all Byzantine shares back to idle EURC in this vault.
+    ///         Pauses deposits atomically. Users can still withdraw from idle balance.
+    function emergencyExitByzantine() external onlyOwner nonReentrant {
+        if (!paused()) _pause();
+        uint256 shares = BYZANTINE_VAULT.balanceOf(address(this));
+        if (shares == 0) return;
+        uint256 withdrawn = BYZANTINE_VAULT.redeem(shares, address(this), address(this));
+        lastTotalAssets      = totalAssets();
+        lastHarvestTimestamp = block.timestamp;
+        emit EmergencyExitV2(withdrawn, block.timestamp);
+    }
+}

--- a/src/PaktolVaultV2.sol
+++ b/src/PaktolVaultV2.sol
@@ -8,7 +8,6 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
-import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 /// @title PaktolVaultV2
 /// @author P.LECROSNIER
@@ -27,7 +26,7 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 ///           - Fee floor at 2% APY: below that, fee scales down with yield.
 ///           - User net yield capped at 5% per year.
 ///           - AUM fee + surplus above cap → treasury.
-///           - Deposits gated via depositWithAuth() — backend signs when tier is active.
+///           - Deposits gated by points: user must hold >= premiumThreshold points.
 ///
 ///         Harvest formula (unified, covers both plans):
 ///           maxAumFee  = lastTotalAssets × FEE_BPS × elapsed / (BPS_DENOMINATOR × SECONDS_PER_YEAR)
@@ -44,9 +43,6 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
 
     uint256 public constant BPS_DENOMINATOR = 10_000;
     uint256 public constant SECONDS_PER_YEAR = 365 days;
-
-    bytes32 public constant DEPOSIT_AUTH_TYPEHASH =
-        keccak256("DepositAuth(address sender,uint256 assets,address receiver,uint256 deadline,uint256 nonce)");
 
     /// @notice APY floor below which the AUM fee is pro-rated down (200 = 2%).
     uint256 public constant FLOOR_BPS = 200;
@@ -71,16 +67,17 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     IERC4626 public immutable BYZANTINE_VAULT;
 
     uint256 public immutable MAX_TVL;
-    address public immutable SIGNER;
     bool public immutable REQUIRES_AUTH;
-    bytes32 public immutable DOMAIN_SEPARATOR;
 
     /* ───────────────────────────── STORAGE ─────────────────────────── */
 
     uint256 public lastTotalAssets;
-    mapping(address => uint256) public nonces;
+    uint256 public lastTreasuryAssets;
     uint256 public lastHarvestTimestamp;
     mapping(address => uint256) public depositTimestamp;
+    mapping(address => uint256) public points;
+    uint256 public premiumThreshold;
+    mapping(address => uint256) public premiumExpiry;
     address public guardian;
     address public harvester;
 
@@ -91,6 +88,9 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     event GuardianChanged(address indexed oldGuardian, address indexed newGuardian);
     event HarvesterChanged(address indexed oldHarvester, address indexed newHarvester);
     event EmergencyExitV2(uint256 amount, uint256 timestamp);
+    event PointsUpdated(address indexed user, uint256 amount);
+    event PremiumThresholdUpdated(uint256 oldThreshold, uint256 newThreshold);
+    event PremiumAccessGranted(address indexed user, uint256 expiry);
 
     /* ───────────────────────────── ERRORS ──────────────────────────── */
 
@@ -104,9 +104,8 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     error TvlCapExceeded(uint256 current, uint256 cap);
     error HarvestTooFrequent(uint256 elapsed, uint256 minimum);
     error InsufficientAllowance();
-    error UseDepositWithAuth();
-    error InvalidSignature();
-    error SignatureExpired();
+    error NotEnoughPoints(uint256 current, uint256 required);
+    error PremiumAccessExpired(uint256 expiredAt);
     error WithdrawalCooldown(uint256 availableAt);
     error RolesNotSeparated();
 
@@ -122,9 +121,9 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     /// @param guardian_       Emergency pause address. Cannot be address(0).
     /// @param harvester_      Keeper bot allowed to call harvest(). Cannot be address(0).
     /// @param byzantineVault_ Byzantine Finance VaultV2 address. Must accept EURC.
-    /// @param maxTvl_         Maximum total assets. 0 = uncapped.
-    /// @param signer_         Backend wallet that signs depositWithAuth. Cannot be address(0).
-    /// @param requiresAuth_   If true, only depositWithAuth() is accepted.
+    /// @param maxTvl_            Maximum total assets. 0 = uncapped.
+    /// @param premiumThreshold_  Minimum points required to deposit in a REQUIRES_AUTH vault.
+    /// @param requiresAuth_      If true, deposits require points >= premiumThreshold.
     constructor(
         IERC20  asset_,
         string memory name_,
@@ -137,7 +136,7 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         address harvester_,
         address byzantineVault_,
         uint256 maxTvl_,
-        address signer_,
+        uint256 premiumThreshold_,
         bool    requiresAuth_
     ) ERC4626(asset_) ERC20(name_, symbol_) Ownable(owner_) {
         if (address(asset_) == address(0)) revert ZeroAddress("asset");
@@ -145,7 +144,6 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         if (guardian_       == address(0)) revert ZeroAddress("guardian");
         if (harvester_      == address(0)) revert ZeroAddress("harvester");
         if (byzantineVault_ == address(0)) revert ZeroAddress("byzantineVault");
-        if (signer_         == address(0)) revert ZeroAddress("signer");
         if (capBps_ == 0 || capBps_ > BPS_DENOMINATOR) revert CapOutOfRange(capBps_);
         if (feeBps_ > FLOOR_BPS) revert FeeOutOfRange(feeBps_);
         if (owner_ == guardian_ || owner_ == harvester_ || guardian_ == harvester_) revert RolesNotSeparated();
@@ -153,23 +151,15 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         address byzantineAsset = IERC4626(byzantineVault_).asset();
         if (byzantineAsset != address(asset_)) revert ByzantineVaultAssetMismatch(byzantineAsset, address(asset_));
 
-        TREASURY       = treasury_;
-        CAP_BPS        = capBps_;
-        FEE_BPS        = feeBps_;
-        guardian       = guardian_;
-        harvester      = harvester_;
+        TREASURY        = treasury_;
+        CAP_BPS         = capBps_;
+        FEE_BPS         = feeBps_;
+        guardian        = guardian_;
+        harvester       = harvester_;
         BYZANTINE_VAULT = IERC4626(byzantineVault_);
-        MAX_TVL        = maxTvl_;
-        SIGNER         = signer_;
-        REQUIRES_AUTH  = requiresAuth_;
-
-        DOMAIN_SEPARATOR = keccak256(abi.encode(
-            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
-            keccak256(bytes(name_)),
-            keccak256("1"),
-            block.chainid,
-            address(this)
-        ));
+        MAX_TVL         = maxTvl_;
+        REQUIRES_AUTH   = requiresAuth_;
+        premiumThreshold = premiumThreshold_;
 
         lastHarvestTimestamp = block.timestamp;
     }
@@ -195,22 +185,33 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         return previewDeposit(maxDep);
     }
 
+    function _byzantineLiquid() internal view returns (uint256) {
+        uint256 idle      = IERC20(asset()).balanceOf(address(this));
+        uint256 byzShares = BYZANTINE_VAULT.balanceOf(address(this));
+        uint256 byzAssets = byzShares > 0 ? BYZANTINE_VAULT.convertToAssets(byzShares) : 0;
+        return idle + byzAssets;
+    }
+
     /// @notice Returns 0 within WITHDRAWAL_COOLDOWN window (vault not paused).
-    ///         Bounded by Byzantine's available liquidity (Morpho redemption queue).
+    ///         Liquid = idle EURC + Byzantine position (convertToAssets of our shares).
+    ///         Using convertToAssets instead of BYZANTINE_VAULT.maxWithdraw() because
+    ///         some vaults (e.g. MetaMorpho sandbox with no configured markets) return
+    ///         maxWithdraw=0 even when funds are fully redeemable.
+    ///         Treasury is exempt: its depositTimestamp is never set (stays 0), so the
+    ///         cooldown check is always false — fee shares can be redeemed immediately.
     function maxWithdraw(address owner_) public view override returns (uint256) {
-        if (!paused() && block.timestamp < depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN) return 0;
+        if (!paused() && owner_ != TREASURY && block.timestamp < depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN) return 0;
         uint256 userAssets = convertToAssets(balanceOf(owner_));
-        uint256 idle       = IERC20(asset()).balanceOf(address(this));
-        uint256 liquid     = idle + BYZANTINE_VAULT.maxWithdraw(address(this));
+        uint256 liquid     = _byzantineLiquid();
         return userAssets < liquid ? userAssets : liquid;
     }
 
     /// @notice Returns 0 within WITHDRAWAL_COOLDOWN window (vault not paused).
+    ///         Treasury exempt — see maxWithdraw.
     function maxRedeem(address owner_) public view override returns (uint256) {
-        if (!paused() && block.timestamp < depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN) return 0;
+        if (!paused() && owner_ != TREASURY && block.timestamp < depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN) return 0;
         uint256 userShares = balanceOf(owner_);
-        uint256 idle       = IERC20(asset()).balanceOf(address(this));
-        uint256 liquid     = idle + BYZANTINE_VAULT.maxWithdraw(address(this));
+        uint256 liquid     = _byzantineLiquid();
         uint256 userAssets = convertToAssets(userShares);
         if (userAssets <= liquid) return userShares;
         return convertToShares(liquid);
@@ -231,28 +232,21 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
     function _depositToByzantine() internal {
         uint256 amount = IERC20(asset()).balanceOf(address(this));
         if (amount == 0) return;
+        uint256 cap = BYZANTINE_VAULT.maxDeposit(address(this));
+        if (cap == 0) return;
+        if (amount > cap) amount = cap;
         IERC20(asset()).forceApprove(address(BYZANTINE_VAULT), amount);
         BYZANTINE_VAULT.deposit(amount, address(this));
-    }
-
-    /// @dev Pulls EURC from Byzantine. Uses idle balance first, then withdraws remainder.
-    function _withdrawFromByzantine(uint256 amount, address to) internal {
-        uint256 idle   = IERC20(asset()).balanceOf(address(this));
-        uint256 needed = idle >= amount ? 0 : amount - idle;
-        if (needed > 0) {
-            BYZANTINE_VAULT.withdraw(needed, address(this), address(this));
-        }
-        if (to != address(this)) {
-            IERC20(asset()).safeTransfer(to, amount);
-        }
     }
 
     /* ──────────────────────── DEPOSIT / WITHDRAW ───────────────────── */
 
     function _syncLastTotalAssets(int256 delta) internal {
         if (delta >= 0) {
+            // forge-lint: disable-next-line(unsafe-typecast)
             lastTotalAssets += uint256(delta);
         } else {
+            // forge-lint: disable-next-line(unsafe-typecast)
             uint256 decrease = uint256(-delta);
             lastTotalAssets = lastTotalAssets > decrease ? lastTotalAssets - decrease : 0;
         }
@@ -264,13 +258,15 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         if (MAX_TVL != 0 && current + assets > MAX_TVL) revert TvlCapExceeded(current, MAX_TVL);
         uint256 shares = super.deposit(assets, receiver);
         _depositToByzantine();
+        // forge-lint: disable-next-line(unsafe-typecast)
         _syncLastTotalAssets(int256(assets));
         depositTimestamp[receiver] = block.timestamp;
         return shares;
     }
 
     function deposit(uint256 assets, address receiver) public override whenNotPaused nonReentrant returns (uint256) {
-        if (REQUIRES_AUTH) revert UseDepositWithAuth();
+        if (REQUIRES_AUTH && block.timestamp > premiumExpiry[receiver])
+            revert PremiumAccessExpired(premiumExpiry[receiver]);
         return _executeDeposit(assets, receiver);
     }
 
@@ -278,7 +274,8 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         uint256 assets,
         address receiver
     ) external whenNotPaused nonReentrant returns (uint256 accepted, uint256 shares) {
-        if (REQUIRES_AUTH) revert UseDepositWithAuth();
+        if (REQUIRES_AUTH && block.timestamp > premiumExpiry[receiver])
+            revert PremiumAccessExpired(premiumExpiry[receiver]);
         uint256 remaining = maxDeposit(receiver);
         if (remaining == 0) return (0, 0);
         accepted = assets > remaining ? remaining : assets;
@@ -295,7 +292,8 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         uint256 deadline,
         uint8 v, bytes32 r, bytes32 s
     ) external whenNotPaused nonReentrant returns (uint256) {
-        if (REQUIRES_AUTH) revert UseDepositWithAuth();
+        if (REQUIRES_AUTH && block.timestamp > premiumExpiry[receiver])
+            revert PremiumAccessExpired(premiumExpiry[receiver]);
         if (assets < MIN_DEPOSIT) revert DepositTooSmall(assets, MIN_DEPOSIT);
         if (IERC20(asset()).allowance(msg.sender, address(this)) < assets) {
             uint256 nonceBefore = IERC20Permit(asset()).nonces(msg.sender);
@@ -305,31 +303,16 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         return _executeDeposit(assets, receiver);
     }
 
-    function depositWithAuth(
-        uint256 assets,
-        address receiver,
-        uint256 deadline,
-        bytes calldata sig
-    ) external whenNotPaused nonReentrant returns (uint256) {
-        if (block.timestamp > deadline) revert SignatureExpired();
-        bytes32 structHash = keccak256(abi.encode(
-            DEPOSIT_AUTH_TYPEHASH,
-            msg.sender, assets, receiver, deadline,
-            nonces[msg.sender]++
-        ));
-        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash));
-        if (ECDSA.recover(digest, sig) != SIGNER) revert InvalidSignature();
-        return _executeDeposit(assets, receiver);
-    }
-
     function mint(uint256 shares, address receiver) public override whenNotPaused nonReentrant returns (uint256) {
-        if (REQUIRES_AUTH) revert UseDepositWithAuth();
+        if (REQUIRES_AUTH && block.timestamp > premiumExpiry[receiver])
+            revert PremiumAccessExpired(premiumExpiry[receiver]);
         uint256 assets = previewMint(shares);
         if (assets < MIN_DEPOSIT) revert DepositTooSmall(assets, MIN_DEPOSIT);
         uint256 current = totalAssets();
         if (MAX_TVL != 0 && current + assets > MAX_TVL) revert TvlCapExceeded(current, MAX_TVL);
         uint256 assetsUsed = super.mint(shares, receiver);
         _depositToByzantine();
+        // forge-lint: disable-next-line(unsafe-typecast)
         _syncLastTotalAssets(int256(assetsUsed));
         depositTimestamp[receiver] = block.timestamp;
         return assetsUsed;
@@ -340,6 +323,7 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
             revert WithdrawalCooldown(depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN);
         }
         uint256 shares = super.withdraw(assets, receiver, owner_);
+        // forge-lint: disable-next-line(unsafe-typecast)
         _syncLastTotalAssets(-int256(assets));
         return shares;
     }
@@ -349,6 +333,7 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
             revert WithdrawalCooldown(depositTimestamp[owner_] + WITHDRAWAL_COOLDOWN);
         }
         uint256 assets = super.redeem(shares, receiver, owner_);
+        // forge-lint: disable-next-line(unsafe-typecast)
         _syncLastTotalAssets(-int256(assets));
         return assets;
     }
@@ -384,7 +369,11 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
 
     /// @notice Collects yield since last harvest and routes it per plan rules.
     ///         Callable by owner or harvester.
-    function harvest() external nonReentrant {
+    ///         Treasury fee is minted as vault shares (Morpho pattern) — no Byzantine
+    ///         withdrawal at harvest time. Treasury shares compound at Morpho APY and
+    ///         are redeemable anytime via redeem(). Treasury is excluded from AUM fee
+    ///         and cap calculations so its shares earn uncapped Morpho yield.
+    function harvest() external nonReentrant whenNotPaused {
         if (msg.sender != owner() && msg.sender != harvester) revert NotHarvester();
 
         uint256 elapsed = block.timestamp - lastHarvestTimestamp;
@@ -393,33 +382,82 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         uint256 current = totalAssets();
 
         if (current <= lastTotalAssets) {
-            lastTotalAssets = current;
+            lastTotalAssets    = current;
+            lastTreasuryAssets = convertToAssets(balanceOf(TREASURY));
             emit HarvestSkipped(current, block.timestamp);
             return;
         }
 
         uint256 grossYield = current - lastTotalAssets;
 
-        uint256 maxAumFee  = (lastTotalAssets * FEE_BPS * elapsed) / (BPS_DENOMINATOR * SECONDS_PER_YEAR);
-        uint256 flooredFee = (grossYield * FEE_BPS) / FLOOR_BPS;
+        // Both snapshots from the same point in time — no timing mismatch.
+        // lastTreasuryAssets is set at the end of each harvest, same block as lastTotalAssets.
+        uint256 userAssets = lastTotalAssets > lastTreasuryAssets
+            ? lastTotalAssets - lastTreasuryAssets
+            : 0;
+
+        // userYield: yield attributable to user capital only (proportional split).
+        uint256 userYield  = lastTotalAssets > 0
+            ? grossYield * userAssets / lastTotalAssets
+            : grossYield;
+
+        uint256 maxAumFee  = (userAssets * FEE_BPS * elapsed) / (BPS_DENOMINATOR * SECONDS_PER_YEAR);
+        uint256 flooredFee = (userYield * FEE_BPS) / FLOOR_BPS;
         uint256 aumFee     = maxAumFee < flooredFee ? maxAumFee : flooredFee;
 
         uint256 remaining   = grossYield - aumFee;
-        uint256 maxNetYield = (lastTotalAssets * CAP_BPS * elapsed) / (BPS_DENOMINATOR * SECONDS_PER_YEAR);
+        uint256 maxNetYield = (userAssets * CAP_BPS * elapsed) / (BPS_DENOMINATOR * SECONDS_PER_YEAR);
         uint256 toUsers     = remaining < maxNetYield ? remaining : maxNetYield;
         uint256 toTreasury  = grossYield - toUsers;
 
-        lastTotalAssets      = current - toTreasury;
+        // Treasury stays in vault — full pool is the new baseline.
+        lastTotalAssets      = current;
         lastHarvestTimestamp = block.timestamp;
 
         emit Harvested(grossYield, toTreasury, toUsers, block.timestamp);
 
+        // Morpho pattern: mint shares to treasury instead of withdrawing assets.
+        // feeShares chosen so treasury receives exactly toTreasury EURC worth of shares.
         if (toTreasury > 0) {
-            _withdrawFromByzantine(toTreasury, TREASURY);
+            uint256 denom = current - toTreasury;
+            if (denom == 0) denom = 1;
+            uint256 feeShares = toTreasury
+                * (totalSupply() + 10 ** _decimalsOffset())
+                / denom;
+            _mint(TREASURY, feeShares);
         }
+
+        // Snapshot treasury value post-mint — used as baseline for next harvest's userAssets.
+        lastTreasuryAssets = convertToAssets(balanceOf(TREASURY));
     }
 
     /* ───────────────────────────── GUARDIAN ────────────────────────── */
+
+    function setPoints(address user, uint256 amount) external onlyOwner {
+        if (user == address(0)) revert ZeroAddress("user");
+        points[user] = amount;
+        emit PointsUpdated(user, amount);
+    }
+
+    /// @notice Grants time-limited access to the premium vault.
+    ///         Backend calls this after verifying the user has enough points.
+    ///         duration is in seconds — e.g. 15 days = 15 * 24 * 3600.
+    function grantPremiumAccess(address user, uint256 duration) external onlyOwner {
+        if (user == address(0)) revert ZeroAddress("user");
+        uint256 expiry = block.timestamp + duration;
+        premiumExpiry[user] = expiry;
+        emit PremiumAccessGranted(user, expiry);
+    }
+
+    function setPremiumThreshold(uint256 threshold) external onlyOwner {
+        emit PremiumThresholdUpdated(premiumThreshold, threshold);
+        premiumThreshold = threshold;
+    }
+
+    function transferOwnership(address newOwner) public override onlyOwner {
+        if (newOwner == guardian || newOwner == harvester) revert RolesNotSeparated();
+        super.transferOwnership(newOwner);
+    }
 
     function setGuardian(address newGuardian_) external onlyOwner {
         if (newGuardian_ == address(0)) revert ZeroAddress("newGuardian");
@@ -456,6 +494,7 @@ contract PaktolVaultV2 is ERC4626, Ownable2Step, Pausable, ReentrancyGuard {
         if (shares == 0) return;
         uint256 withdrawn = BYZANTINE_VAULT.redeem(shares, address(this), address(this));
         lastTotalAssets      = totalAssets();
+        lastTreasuryAssets   = convertToAssets(balanceOf(TREASURY));
         lastHarvestTimestamp = block.timestamp;
         emit EmergencyExitV2(withdrawn, block.timestamp);
     }

--- a/test/PaktolVault.fork.t.sol
+++ b/test/PaktolVault.fork.t.sol
@@ -128,7 +128,7 @@ contract PaktolVaultForkTest is Test {
         vault.harvest();
 
         assertEq(vault.lastHarvestTimestamp(), block.timestamp, "timestamp updated");
-        assertEq(vault.lastTotalAssets(), vault.totalAssets(), "snapshot updated");
+        assertApproxEqAbs(vault.lastTotalAssets(), vault.totalAssets(), 1, "snapshot updated");
 
         uint256 totalAfter = vault.totalAssets();
         if (totalAfter > totalBefore) {

--- a/test/PaktolVaultV2.admin.t.sol
+++ b/test/PaktolVaultV2.admin.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./PaktolVaultV2Base.t.sol";
+
+contract PaktolVaultV2AdminTest is PaktolVaultV2Base {
+
+    /* ────────────────────── PAUSE / GUARDIAN ───────────────────────── */
+
+    function test_pause_byGuardian() public {
+        vm.prank(guardian);
+        vaultStd.pause();
+        assertTrue(vaultStd.paused());
+    }
+
+    function test_pause_byOwner() public {
+        vm.prank(owner);
+        vaultStd.pause();
+        assertTrue(vaultStd.paused());
+    }
+
+    function test_pause_revert_unauthorized() public {
+        vm.expectRevert(PaktolVaultV2.NotGuardian.selector);
+        vm.prank(user);
+        vaultStd.pause();
+    }
+
+    function test_unpause_byOwner() public {
+        vm.prank(guardian);
+        vaultStd.pause();
+        vm.prank(owner);
+        vaultStd.unpause();
+        assertFalse(vaultStd.paused());
+    }
+
+    function test_unpause_revert_guardian() public {
+        vm.prank(guardian);
+        vaultStd.pause();
+        vm.expectRevert();
+        vm.prank(guardian);
+        vaultStd.unpause();
+    }
+
+    /* ──────────────────────────── ADMIN ────────────────────────────── */
+
+    function test_setGuardian() public {
+        address newGuardian = makeAddr("newGuardian");
+        vm.prank(owner);
+        vaultStd.setGuardian(newGuardian);
+        assertEq(vaultStd.guardian(), newGuardian);
+    }
+
+    function test_setGuardian_revert_zeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.ZeroAddress.selector, "newGuardian"));
+        vm.prank(owner);
+        vaultStd.setGuardian(address(0));
+    }
+
+    function test_setGuardian_revert_unauthorized() public {
+        vm.expectRevert();
+        vm.prank(user);
+        vaultStd.setGuardian(makeAddr("x"));
+    }
+
+    // F-14: role separation in setGuardian / setHarvester.
+    function test_f14_setGuardian_revert_equalsOwner() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        vm.prank(owner);
+        vaultStd.setGuardian(owner);
+    }
+
+    function test_f14_setGuardian_revert_equalsHarvester() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        vm.prank(owner);
+        vaultStd.setGuardian(harvester);
+    }
+
+    function test_setHarvester() public {
+        address newHarvester = makeAddr("newHarvester");
+        vm.prank(owner);
+        vaultStd.setHarvester(newHarvester);
+        assertEq(vaultStd.harvester(), newHarvester);
+    }
+
+    function test_setHarvester_revert_zeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.ZeroAddress.selector, "newHarvester"));
+        vm.prank(owner);
+        vaultStd.setHarvester(address(0));
+    }
+
+    function test_setHarvester_revert_unauthorized() public {
+        vm.expectRevert();
+        vm.prank(user);
+        vaultStd.setHarvester(makeAddr("x"));
+    }
+
+    function test_f14_setHarvester_revert_equalsOwner() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        vm.prank(owner);
+        vaultStd.setHarvester(owner);
+    }
+
+    function test_f14_setHarvester_revert_equalsGuardian() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        vm.prank(owner);
+        vaultStd.setHarvester(guardian);
+    }
+
+    /* ─────────── M-2: transferOwnership role separation ────────────── */
+
+    function test_m2_transferOwnership_revert_toGuardian() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        vm.prank(owner);
+        vaultStd.transferOwnership(guardian);
+    }
+
+    function test_m2_transferOwnership_revert_toHarvester() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        vm.prank(owner);
+        vaultStd.transferOwnership(harvester);
+    }
+
+    function test_m2_transferOwnership_ok_toNewAddress() public {
+        address newOwner = makeAddr("newOwner");
+        vm.prank(owner);
+        vaultStd.transferOwnership(newOwner);
+        // Ownable2Step: newOwner must accept
+        vm.prank(newOwner);
+        vaultStd.acceptOwnership();
+        assertEq(vaultStd.owner(), newOwner);
+    }
+}

--- a/test/PaktolVaultV2.constructor.t.sol
+++ b/test/PaktolVaultV2.constructor.t.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./PaktolVaultV2Base.t.sol";
+
+contract PaktolVaultV2ConstructorTest is PaktolVaultV2Base {
+
+    function test_constructor_immutables() public view {
+        assertEq(vaultStd.CAP_BPS(),   CAP_STD);
+        assertEq(vaultStd.FEE_BPS(),   FEE_STD);
+        assertEq(vaultStd.TREASURY(),  treasury);
+        assertEq(address(vaultStd.BYZANTINE_VAULT()), address(mockStd));
+        assertEq(vaultStd.guardian(),  guardian);
+        assertEq(vaultStd.harvester(), harvester);
+        assertFalse(vaultStd.REQUIRES_AUTH());
+        assertEq(vaultStd.premiumThreshold(), 0);
+        assertEq(vaultPkt.premiumThreshold(), PREMIUM_THRESHOLD);
+
+        assertEq(vaultPkt.CAP_BPS(), CAP_PKT);
+        assertEq(vaultPkt.FEE_BPS(), FEE_PKT);
+        assertTrue(vaultPkt.REQUIRES_AUTH());
+    }
+
+    function test_constructor_revert_zeroAsset() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.ZeroAddress.selector, "asset"));
+        new PaktolVaultV2(
+            IERC20(address(0)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, harvester, address(mockStd), 0, 0, false
+        );
+    }
+
+    function test_constructor_revert_zeroTreasury() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.ZeroAddress.selector, "treasury"));
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, address(0), CAP_STD, FEE_STD,
+            guardian, harvester, address(mockStd), 0, 0, false
+        );
+    }
+
+    function test_constructor_revert_zeroByzantineVault() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.ZeroAddress.selector, "byzantineVault"));
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, harvester, address(0), 0, 0, false
+        );
+    }
+
+    function test_constructor_revert_assetMismatch() public {
+        MockEURC other = new MockEURC();
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVaultV2.ByzantineVaultAssetMismatch.selector,
+            address(eurc),
+            address(other)
+        ));
+        new PaktolVaultV2(
+            IERC20(address(other)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, harvester, address(mockStd), 0, 0, false
+        );
+    }
+
+    function test_constructor_revert_capZero() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.CapOutOfRange.selector, 0));
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, 0, FEE_STD,
+            guardian, harvester, address(mockStd), 0, 0, false
+        );
+    }
+
+    function test_constructor_revert_capAboveMax() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.CapOutOfRange.selector, 10_001));
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, 10_001, FEE_STD,
+            guardian, harvester, address(mockStd), 0, 0, false
+        );
+    }
+
+    function test_constructor_revert_fee100pct() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.FeeOutOfRange.selector, 10_000));
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, 10_000,
+            guardian, harvester, address(mockStd), 0, 0, false
+        );
+    }
+
+    // F-21: FEE_BPS > FLOOR_BPS causes harvest() DoS — tighten constructor bound.
+    function test_f21_constructor_revert_fee_above_floor_bps() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.FeeOutOfRange.selector, 201));
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, 201,
+            guardian, harvester, address(mockStd), 0, 0, false
+        );
+    }
+
+    function test_f21_constructor_accepts_fee_at_floor_bps() public {
+        PaktolVaultV2 v = new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, 200,
+            guardian, harvester, address(mockStd), 0, 0, false
+        );
+        assertEq(v.FEE_BPS(), 200);
+    }
+
+    // F-14: role separation enforced in constructor.
+    function test_f14_constructor_revert_ownerEqualsGuardian() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            owner, harvester, address(mockStd), 0, 0, false
+        );
+    }
+
+    function test_f14_constructor_revert_ownerEqualsHarvester() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, owner, address(mockStd), 0, 0, false
+        );
+    }
+
+    function test_f14_constructor_revert_guardianEqualsHarvester() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, guardian, address(mockStd), 0, 0, false
+        );
+    }
+}

--- a/test/PaktolVaultV2.deposit.t.sol
+++ b/test/PaktolVaultV2.deposit.t.sol
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./PaktolVaultV2Base.t.sol";
+
+contract PaktolVaultV2DepositTest is PaktolVaultV2Base {
+
+    /* ─────────────────── DEPOSIT → BYZANTINE ROUTING ───────────────── */
+
+    function test_deposit_basic() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        assertGt(shares, 0);
+        assertEq(vaultStd.totalAssets(), DEPOSIT);
+        assertEq(eurc.balanceOf(address(vaultStd)), 0, "no idle EURC");
+        assertGt(mockStd.balanceOf(address(vaultStd)), 0, "vault holds Byzantine shares");
+    }
+
+    function test_deposit_updates_lastTotalAssets() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        assertEq(vaultStd.lastTotalAssets(), DEPOSIT);
+    }
+
+    function test_deposit_revert_tooSmall() public {
+        uint256 tiny = vaultStd.MIN_DEPOSIT() - 1;
+        eurc.mint(user, tiny);
+        vm.startPrank(user);
+        eurc.approve(address(vaultStd), tiny);
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.DepositTooSmall.selector, tiny, vaultStd.MIN_DEPOSIT()));
+        vaultStd.deposit(tiny, user);
+        vm.stopPrank();
+    }
+
+    function test_deposit_revert_whenPaused() public {
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        vm.startPrank(user);
+        eurc.approve(address(vaultStd), DEPOSIT);
+        vm.expectRevert();
+        vaultStd.deposit(DEPOSIT, user);
+        vm.stopPrank();
+    }
+
+    // F-19: depositUpToCap.
+    function test_f19_depositUpToCap_full_when_under_cap() public {
+        PaktolVaultV2 capped = new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, harvester, address(mockStd), 2_000e6, 0, false
+        );
+        eurc.mint(user, 1_000e6);
+        vm.startPrank(user);
+        eurc.approve(address(capped), 1_000e6);
+        (uint256 accepted, uint256 shares) = capped.depositUpToCap(1_000e6, user);
+        vm.stopPrank();
+
+        assertEq(accepted, 1_000e6, "full amount accepted");
+        assertGt(shares, 0);
+    }
+
+    function test_f19_depositUpToCap_truncates_at_cap() public {
+        uint256 cap = 1_500e6;
+        PaktolVaultV2 capped = new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, harvester, address(mockStd), cap, 0, false
+        );
+        eurc.mint(user, 1_000e6);
+        vm.startPrank(user);
+        eurc.approve(address(capped), 1_000e6);
+        capped.deposit(1_000e6, user);
+        vm.stopPrank();
+
+        _warp(capped.WITHDRAWAL_COOLDOWN());
+
+        eurc.mint(user2, 1_000e6);
+        vm.startPrank(user2);
+        eurc.approve(address(capped), 1_000e6);
+        (uint256 accepted, uint256 shares) = capped.depositUpToCap(1_000e6, user2);
+        vm.stopPrank();
+
+        assertApproxEqAbs(accepted, 500e6, 1e3, "truncated to remaining capacity");
+        assertGt(shares, 0);
+        assertApproxEqAbs(capped.totalAssets(), cap, 1e3, "vault at cap");
+    }
+
+    function test_f19_depositUpToCap_returns_zero_when_full() public {
+        uint256 cap = 1_000e6;
+        PaktolVaultV2 capped = new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, harvester, address(mockStd), cap, 0, false
+        );
+        eurc.mint(user, cap);
+        vm.startPrank(user);
+        eurc.approve(address(capped), cap);
+        capped.deposit(cap, user);
+        vm.stopPrank();
+
+        _warp(capped.WITHDRAWAL_COOLDOWN());
+
+        eurc.mint(user2, 500e6);
+        vm.startPrank(user2);
+        eurc.approve(address(capped), 500e6);
+        (uint256 accepted, uint256 shares) = capped.depositUpToCap(500e6, user2);
+        vm.stopPrank();
+
+        assertEq(accepted, 0, "nothing accepted when cap full");
+        assertEq(shares, 0);
+    }
+
+    function test_f19_deposit_still_reverts_at_cap() public {
+        uint256 cap = 1_000e6;
+        PaktolVaultV2 capped = new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, harvester, address(mockStd), cap, 0, false
+        );
+        eurc.mint(user, cap + 1e6);
+        vm.startPrank(user);
+        eurc.approve(address(capped), cap + 1e6);
+        capped.deposit(cap, user);
+        _warp(capped.WITHDRAWAL_COOLDOWN());
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.TvlCapExceeded.selector, capped.totalAssets(), cap));
+        capped.deposit(1e6, user);
+        vm.stopPrank();
+    }
+
+    /* ──────────────────────────── MINT ─────────────────────────────── */
+
+    function test_mint_basic() public {
+        uint256 sharesToMint = 500e9;
+        vm.startPrank(user);
+        eurc.approve(address(vaultStd), DEPOSIT);
+        uint256 assetsUsed = vaultStd.mint(sharesToMint, user);
+        vm.stopPrank();
+
+        assertGt(assetsUsed, 0);
+        assertEq(vaultStd.balanceOf(user), sharesToMint);
+        assertEq(eurc.balanceOf(address(vaultStd)), 0, "no idle EURC after mint");
+    }
+
+    /* ─────────────────────── WITHDRAW / REDEEM ─────────────────────── */
+
+    function test_withdraw_basic() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+        uint256 balBefore = eurc.balanceOf(user);
+
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT, user, user);
+
+        assertEq(eurc.balanceOf(user), balBefore + DEPOSIT);
+        assertEq(vaultStd.totalAssets(), 0);
+    }
+
+    function test_withdraw_works_when_paused() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        uint256 balBefore = eurc.balanceOf(user);
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT, user, user);
+
+        assertApproxEqAbs(eurc.balanceOf(user), balBefore + DEPOSIT, 1e3);
+    }
+
+    function test_redeem_basic() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+        uint256 balBefore = eurc.balanceOf(user);
+
+        vm.prank(user);
+        vaultStd.redeem(shares, user, user);
+
+        assertApproxEqAbs(eurc.balanceOf(user), balBefore + DEPOSIT, 1e3);
+        assertApproxEqAbs(vaultStd.totalAssets(), 0, 1e3);
+    }
+
+    function test_withdraw_updates_lastTotalAssets() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT / 2, user, user);
+
+        assertApproxEqAbs(vaultStd.lastTotalAssets(), DEPOSIT / 2, 1e3);
+    }
+
+    /* ──────────── totalAssets reflects Byzantine yield ─────────────── */
+
+    function test_totalAssets_reflectsYield() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        uint256 before = vaultStd.totalAssets();
+
+        mockStd.simulateYield(500e6);
+
+        assertGt(vaultStd.totalAssets(), before);
+    }
+}

--- a/test/PaktolVaultV2.emergency.t.sol
+++ b/test/PaktolVaultV2.emergency.t.sol
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./PaktolVaultV2Base.t.sol";
+
+contract PaktolVaultV2EmergencyTest is PaktolVaultV2Base {
+
+    /* ────────────────────── EMERGENCY EXIT ─────────────────────────── */
+
+    function test_emergencyExit_pullsAllFromByzantine() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        assertGt(mockStd.balanceOf(address(vaultStd)), 0);
+        assertEq(eurc.balanceOf(address(vaultStd)), 0);
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        assertEq(mockStd.balanceOf(address(vaultStd)), 0, "no Byzantine shares after exit");
+        assertApproxEqAbs(eurc.balanceOf(address(vaultStd)), DEPOSIT, 1e3, "idle EURC after exit");
+    }
+
+    function test_emergencyExit_usersCanWithdraw() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        uint256 balBefore = eurc.balanceOf(user);
+        vm.prank(user);
+        vaultStd.redeem(shares, user, user);
+
+        assertApproxEqAbs(eurc.balanceOf(user), balBefore + DEPOSIT, 1e3);
+    }
+
+    function test_emergencyExit_emitsEvent() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.expectEmit(false, false, false, false);
+        emit PaktolVaultV2.EmergencyExitV2(0, 0);
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+    }
+
+    function test_emergencyExit_noOp_whenNoBalance() public {
+        // No deposit — Byzantine shares = 0. Should not revert.
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+    }
+
+    function test_emergencyExit_revert_unauthorized() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.expectRevert();
+        vm.prank(user);
+        vaultStd.emergencyExitByzantine();
+
+        vm.expectRevert();
+        vm.prank(guardian);
+        vaultStd.emergencyExitByzantine();
+    }
+
+    /// @dev F-11: emergencyExitByzantine() must pause atomically.
+    function test_f11_emergencyExit_autopause() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        assertFalse(vaultStd.paused());
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        assertTrue(vaultStd.paused(), "vault must be paused after emergency exit");
+
+        vm.startPrank(user);
+        eurc.approve(address(vaultStd), DEPOSIT);
+        vm.expectRevert();
+        vaultStd.deposit(DEPOSIT, user);
+        vm.stopPrank();
+    }
+
+    /// @dev F-11: emergencyExitByzantine() on an already-paused vault must not revert.
+    function test_f11_emergencyExit_alreadyPaused_noRevert() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        assertTrue(vaultStd.paused());
+        assertEq(mockStd.balanceOf(address(vaultStd)), 0);
+    }
+
+    /// @dev F-11: accounting snapshot after emergency exit is clean.
+    function test_f11_emergencyExit_updatesAccounting() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        mockStd.simulateYield(20e6);
+        _warp(7 days);
+
+        uint256 tsBefore = vaultStd.lastHarvestTimestamp();
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        assertEq(vaultStd.lastTotalAssets(),    vaultStd.totalAssets(),   "lastTotalAssets must reflect post-exit state");
+        assertGt(vaultStd.lastHarvestTimestamp(), tsBefore,               "lastHarvestTimestamp must be reset");
+        assertEq(vaultStd.lastTreasuryAssets(),
+            vaultStd.convertToAssets(vaultStd.balanceOf(treasury)),       "lastTreasuryAssets must be synced on exit");
+    }
+
+    /// @dev F-11: lastTreasuryAssets stays consistent after exit so next harvest userAssets is correct.
+    function test_f11_emergencyExit_treasury_snapshot_consistent() public {
+        // Harvest 1 — treasury accumulates shares.
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(40e6);
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 treasurySnapshotAfterH1 = vaultStd.lastTreasuryAssets();
+        assertGt(treasurySnapshotAfterH1, 0, "treasury must have shares after H1");
+
+        // Emergency exit — all Byzantine shares redeemed, vault paused.
+        _warp(1 days);
+        mockStd.simulateYield(5e6);
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        uint256 currentTreasuryValue = vaultStd.convertToAssets(vaultStd.balanceOf(treasury));
+        assertEq(
+            vaultStd.lastTreasuryAssets(),
+            currentTreasuryValue,
+            "lastTreasuryAssets must be synced with lastTotalAssets after exit"
+        );
+
+        // Unpause and harvest — userAssets must be computed from consistent snapshots.
+        vm.prank(owner);
+        vaultStd.unpause();
+        _warp(365 days);
+
+        eurc.mint(address(vaultStd), 10e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertEq(
+            vaultStd.lastTreasuryAssets(),
+            vaultStd.convertToAssets(vaultStd.balanceOf(treasury)),
+            "lastTreasuryAssets must remain consistent after post-exit harvest"
+        );
+    }
+
+    /* ─────────────────── F-09: WITHDRAWAL COOLDOWN ─────────────────── */
+
+    function test_f09_cooldown_blocks_immediate_withdraw() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVaultV2.WithdrawalCooldown.selector,
+            block.timestamp + vaultStd.WITHDRAWAL_COOLDOWN()
+        ));
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT, user, user);
+    }
+
+    function test_f09_cooldown_blocks_immediate_redeem() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVaultV2.WithdrawalCooldown.selector,
+            block.timestamp + vaultStd.WITHDRAWAL_COOLDOWN()
+        ));
+        vm.prank(user);
+        vaultStd.redeem(shares, user, user);
+    }
+
+    function test_f09_cooldown_allows_withdraw_after_delay() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+
+        uint256 balBefore = eurc.balanceOf(user);
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT, user, user);
+
+        assertApproxEqAbs(eurc.balanceOf(user), balBefore + DEPOSIT, 1e3);
+    }
+
+    function test_f09_sandwich_blocked_by_cooldown() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(35e6);
+
+        address attacker = address(this);
+        eurc.mint(attacker, DEPOSIT);
+        vm.startPrank(attacker);
+        eurc.approve(address(vaultStd), DEPOSIT);
+        uint256 attackShares = vaultStd.deposit(DEPOSIT, attacker);
+        vm.stopPrank();
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        vm.expectRevert();
+        vm.prank(attacker);
+        vaultStd.redeem(attackShares, attacker, attacker);
+    }
+
+    function test_f09_cooldown_independent_per_user() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+        _deposit(vaultStd, user2, DEPOSIT);
+
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT, user, user);
+
+        vm.expectRevert();
+        vm.prank(user2);
+        vaultStd.withdraw(DEPOSIT, user2, user2);
+    }
+
+    function test_f09_cooldown_propagated_on_transfer() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        address attacker2 = makeAddr("attacker2");
+
+        vm.prank(user);
+        vaultStd.transfer(attacker2, shares);
+
+        assertEq(vaultStd.depositTimestamp(attacker2), vaultStd.depositTimestamp(user));
+
+        vm.expectRevert();
+        vm.prank(attacker2);
+        vaultStd.redeem(shares, attacker2, attacker2);
+    }
+
+    function test_f09_cooldown_bypassed_when_paused() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        uint256 balBefore = eurc.balanceOf(user);
+        vm.prank(user);
+        vaultStd.redeem(shares, user, user);
+
+        assertApproxEqAbs(eurc.balanceOf(user), balBefore + DEPOSIT, 1e3);
+    }
+
+    function test_f09_maxWithdraw_zero_during_cooldown() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        assertEq(vaultStd.maxWithdraw(user), 0, "maxWithdraw must be 0 during cooldown");
+        assertEq(vaultStd.maxRedeem(user),   0, "maxRedeem must be 0 during cooldown");
+
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+
+        assertGt(vaultStd.maxWithdraw(user), 0);
+        assertGt(vaultStd.maxRedeem(user),   0);
+    }
+}

--- a/test/PaktolVaultV2.harvest.t.sol
+++ b/test/PaktolVaultV2.harvest.t.sol
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./PaktolVaultV2Base.t.sol";
+
+contract PaktolVaultV2HarvestTest is PaktolVaultV2Base {
+
+    /* ───────────────── HARVEST — STANDARD (exact math) ─────────────── */
+
+    function test_harvest_std_belowCap() public {
+        // 20 EURC yield on 1000 = 2% gross, 1 year.
+        // aumFee = 1000 × 0.5% = 5  | flooredFee = 20 × 50/200 = 5 → aumFee = 5
+        // remaining = 15 | maxNetYield = 1000 × 3.5% = 35 → toUsers = 15, toTreasury = 5
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(20e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 expectedFee = (DEPOSIT * FEE_STD) / 10_000; // 5 EURC
+        assertApproxEqAbs(vaultStd.convertToAssets(vaultStd.balanceOf(treasury)), expectedFee, 1e3);
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT + 20e6, 1e3);
+    }
+
+    function test_harvest_std_atCap() public {
+        // 40 EURC yield = 4% gross. aumFee = 5, remaining = 35 = maxNetYield → toTreasury = 5
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(40e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertApproxEqAbs(vaultStd.convertToAssets(vaultStd.balanceOf(treasury)), 5e6, 1e3);
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT + 40e6, 1e3);
+    }
+
+    function test_harvest_std_aboveCap() public {
+        // 60 EURC yield = 6% gross.
+        // aumFee = 5, remaining = 55, maxNetYield = 35 → toUsers = 35, toTreasury = 25
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(60e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertApproxEqAbs(vaultStd.convertToAssets(vaultStd.balanceOf(treasury)), 25e6, 1e3);
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT + 60e6, 1e3);
+    }
+
+    function test_harvest_std_noYield() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertEq(eurc.balanceOf(treasury), 0);
+        assertEq(vaultStd.totalAssets(), DEPOSIT);
+    }
+
+    function test_harvest_std_loss() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateLoss(100e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest(); // must not revert, no treasury payment
+
+        assertEq(eurc.balanceOf(treasury), 0);
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT - 100e6, 1e3);
+    }
+
+    function test_harvest_std_emitsEvent() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(40e6);
+
+        vm.expectEmit(false, false, false, false);
+        emit PaktolVaultV2.Harvested(0, 0, 0, 0);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+    }
+
+    function test_harvest_std_belowFloor() public {
+        // APY = 1.5% (below 2% floor) — fee is pro-rated down.
+        // grossYield = 15 | flooredFee = 15 × 50/200 = 3.75 < maxAumFee 5 → aumFee = 3.75
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(15e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 expectedFee = (15e6 * 50) / 200; // 3.75 EURC
+        assertApproxEqAbs(vaultStd.convertToAssets(vaultStd.balanceOf(treasury)), expectedFee, 1e3);
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT + 15e6, 1e3);
+    }
+
+    function test_harvest_std_atFloor() public {
+        // APY = 2% exactly — flooredFee == maxAumFee, seamless transition.
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(20e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 expectedFee = (DEPOSIT * FEE_STD) / 10_000; // 5 EURC
+        assertApproxEqAbs(vaultStd.convertToAssets(vaultStd.balanceOf(treasury)), expectedFee, 1e3);
+    }
+
+    /* ─────────────────── HARVEST — PREMIUM (FEE=0.5%) ──────────────── */
+
+    function test_harvest_pkt_belowCap() public {
+        // 40 EURC = 4% gross, AUM fee = 5e6, remaining = 35e6 < cap(50e6) → toUsers=35e6, toTreasury=5e6
+        _depositPremium(user, DEPOSIT);
+        _warp(365 days);
+        mockPkt.simulateYield(40e6);
+
+        vm.prank(harvester);
+        vaultPkt.harvest();
+
+        assertApproxEqAbs(vaultPkt.convertToAssets(vaultPkt.balanceOf(treasury)), 5e6, 1e3);
+        assertApproxEqAbs(vaultPkt.totalAssets(), DEPOSIT + 40e6, 1e3);
+    }
+
+    function test_harvest_pkt_atCap() public {
+        // 50 EURC = 5% gross, AUM fee = 5e6, remaining = 45e6 < cap(50e6) → toUsers=45e6, toTreasury=5e6
+        _depositPremium(user, DEPOSIT);
+        _warp(365 days);
+        mockPkt.simulateYield(50e6);
+
+        vm.prank(harvester);
+        vaultPkt.harvest();
+
+        assertApproxEqAbs(vaultPkt.convertToAssets(vaultPkt.balanceOf(treasury)), 5e6, 1e3);
+        assertApproxEqAbs(vaultPkt.totalAssets(), DEPOSIT + 50e6, 1e3);
+    }
+
+    function test_harvest_pkt_aboveCap() public {
+        // 70 EURC = 7% gross, AUM fee = 5e6, remaining = 65e6 > cap(50e6) → toUsers=50e6, toTreasury=20e6
+        _depositPremium(user, DEPOSIT);
+        _warp(365 days);
+        mockPkt.simulateYield(70e6);
+
+        vm.prank(harvester);
+        vaultPkt.harvest();
+
+        assertApproxEqAbs(vaultPkt.convertToAssets(vaultPkt.balanceOf(treasury)), 20e6, 1e3);
+        assertApproxEqAbs(vaultPkt.totalAssets(), DEPOSIT + 70e6, 1e3);
+    }
+
+    /* ──────────────────────── HARVEST GUARDS ────────────────────────── */
+
+    function test_harvest_revert_unauthorized() public {
+        vm.expectRevert(PaktolVaultV2.NotHarvester.selector);
+        vm.prank(user);
+        vaultStd.harvest();
+    }
+
+    function test_harvest_owner_canHarvest() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(40e6);
+
+        vm.prank(owner);
+        vaultStd.harvest();
+
+        assertGt(vaultStd.convertToAssets(vaultStd.balanceOf(treasury)), 0);
+    }
+
+    function test_harvest_revert_tooFrequent() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        mockStd.simulateYield(40e6);
+        _warp(vaultStd.MIN_HARVEST_INTERVAL() - 1);
+
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVaultV2.HarvestTooFrequent.selector,
+            vaultStd.MIN_HARVEST_INTERVAL() - 1,
+            vaultStd.MIN_HARVEST_INTERVAL()
+        ));
+        vm.prank(harvester);
+        vaultStd.harvest();
+    }
+
+    function test_harvest_updatesTimestamp() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(7 days);
+        mockStd.simulateYield(10e6);
+
+        uint256 before = vaultStd.lastHarvestTimestamp();
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertGt(vaultStd.lastHarvestTimestamp(), before);
+    }
+
+    /// @dev F-20: no-yield harvest must NOT advance lastHarvestTimestamp.
+    function test_f20_noYield_harvest_preserves_timestamp() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(7 days);
+
+        uint256 tsBefore = vaultStd.lastHarvestTimestamp();
+
+        vm.prank(harvester);
+        vaultStd.harvest(); // no yield → early return
+
+        assertEq(vaultStd.lastHarvestTimestamp(), tsBefore, "timestamp must not advance on no-yield harvest");
+
+        // Real yield accrues later — full elapsed window is preserved.
+        _warp(30 days);
+        mockStd.simulateYield(35e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 elapsed = 37 days;
+        uint256 maxNetYield = (DEPOSIT * 350 * elapsed) / (10_000 * 365 days);
+        assertGe(vaultStd.totalAssets(), DEPOSIT + maxNetYield - 1e3, "full cap window must be applied");
+    }
+
+    /* ─────────── F-18: lastTotalAssets accounting invariant ────────── */
+
+    function test_f18_deposit_does_not_absorb_pending_yield() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        assertEq(vaultStd.lastTotalAssets(), DEPOSIT);
+
+        uint256 yieldAmount = 50e6;
+        mockStd.simulateYield(yieldAmount);
+
+        uint256 deposit2 = 200e6;
+        _deposit(vaultStd, user2, deposit2);
+
+        assertEq(vaultStd.lastTotalAssets(), DEPOSIT + deposit2, "deposit must not absorb pending yield");
+
+        _warp(365 days);
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertGt(vaultStd.convertToAssets(vaultStd.balanceOf(treasury)), 0, "treasury must receive yield from pre-deposit accumulation");
+    }
+
+    function test_f18_withdraw_does_not_absorb_pending_yield() public {
+        _deposit(vaultStd, user,  DEPOSIT);
+        _deposit(vaultStd, user2, DEPOSIT);
+
+        uint256 yieldAmount = 50e6;
+        mockStd.simulateYield(yieldAmount);
+
+        uint256 withdrawAmount = 200e6;
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+        vm.prank(user);
+        vaultStd.withdraw(withdrawAmount, user, user);
+
+        assertEq(vaultStd.lastTotalAssets(), 2 * DEPOSIT - withdrawAmount, "withdraw must not absorb pending yield");
+
+        _warp(365 days);
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertGt(vaultStd.convertToAssets(vaultStd.balanceOf(treasury)), 0, "treasury must receive yield from pre-withdrawal accumulation");
+    }
+
+    /* ──────────────────────────── FUZZ ─────────────────────────────── */
+
+    function testFuzz_deposit_withdraw_roundtrip(uint256 amount) public {
+        amount = bound(amount, vaultStd.MIN_DEPOSIT(), 1_000_000e6);
+
+        uint256 shares = _deposit(vaultStd, user, amount);
+        assertApproxEqAbs(vaultStd.totalAssets(), amount, 1e3);
+
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+        vm.prank(user);
+        vaultStd.redeem(shares, user, user);
+
+        assertApproxEqAbs(eurc.balanceOf(user), USER_BALANCE + amount, 1e3);
+    }
+
+    function testFuzz_harvest_std_userNeverExceedsCap(uint256 yieldBps) public {
+        yieldBps = bound(yieldBps, 0, 1_000);
+        uint256 yieldAmount = (DEPOSIT * yieldBps) / 10_000;
+
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        if (yieldAmount > 0) mockStd.simulateYield(yieldAmount);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 userAssets    = vaultStd.convertToAssets(vaultStd.balanceOf(user));
+        uint256 maxUserAssets = DEPOSIT + (DEPOSIT * CAP_STD) / 10_000;
+        assertLe(userAssets, maxUserAssets + 1e3);
+    }
+
+    function testFuzz_harvest_pkt_userNeverExceedsCap(uint256 yieldBps) public {
+        yieldBps = bound(yieldBps, 0, 1_500);
+        uint256 yieldAmount = (DEPOSIT * yieldBps) / 10_000;
+
+        _depositPremium(user, DEPOSIT);
+        _warp(365 days);
+        if (yieldAmount > 0) mockPkt.simulateYield(yieldAmount);
+
+        vm.prank(harvester);
+        vaultPkt.harvest();
+
+        uint256 userAssets    = vaultPkt.convertToAssets(vaultPkt.balanceOf(user));
+        uint256 maxUserAssets = DEPOSIT + (DEPOSIT * CAP_PKT) / 10_000;
+        assertLe(userAssets, maxUserAssets + 1e3);
+    }
+
+    /* ───────────────────── L-1: harvest blocked when paused ────────── */
+
+    function test_l1_harvest_reverts_when_paused() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(20e6);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        vm.prank(harvester);
+        vm.expectRevert();
+        vaultStd.harvest();
+    }
+}

--- a/test/PaktolVaultV2.multiuser.t.sol
+++ b/test/PaktolVaultV2.multiuser.t.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./PaktolVaultV2Base.t.sol";
+
+contract PaktolVaultV2MultiUserTest is PaktolVaultV2Base {
+
+    /* ──────────────────────── MULTI-USER ───────────────────────────── */
+
+    function test_multiUser_equalShares() public {
+        uint256 shares1 = _deposit(vaultStd, user,  DEPOSIT);
+        uint256 shares2 = _deposit(vaultStd, user2, DEPOSIT);
+        assertEq(shares1, shares2);
+    }
+
+    function test_multiUser_proportionalYield() public {
+        _deposit(vaultStd, user,  DEPOSIT);
+        _deposit(vaultStd, user2, DEPOSIT);
+
+        _warp(365 days);
+        mockStd.simulateYield(70e6); // 3.5% for each user = 70 total
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 assets1 = vaultStd.convertToAssets(vaultStd.balanceOf(user));
+        uint256 assets2 = vaultStd.convertToAssets(vaultStd.balanceOf(user2));
+
+        assertApproxEqAbs(assets1, assets2, 1e3);
+
+        uint256 aumFee      = (2 * DEPOSIT * FEE_STD) / 10_000; // 10 EURC
+        uint256 expectedNet = (70e6 - aumFee) / 2;
+        assertApproxEqAbs(assets1, DEPOSIT + expectedNet, 1e3);
+    }
+
+    function test_multiUser_laterDepositor_noBackpay() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(35e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 expectedNet = 35e6 - (DEPOSIT * FEE_STD) / 10_000;
+        assertApproxEqAbs(vaultStd.convertToAssets(vaultStd.balanceOf(user)), DEPOSIT + expectedNet, 1e3);
+
+        uint256 shares2 = _deposit(vaultStd, user2, DEPOSIT);
+        assertApproxEqAbs(vaultStd.convertToAssets(shares2), DEPOSIT, 1e3);
+    }
+
+    /* ─────────────── MAX WITHDRAW / REDEEM ─────────────────────────── */
+
+    function test_maxWithdraw_fullLiquidity() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+
+        uint256 expected = vaultStd.convertToAssets(vaultStd.balanceOf(user));
+        assertApproxEqAbs(vaultStd.maxWithdraw(user), expected, 1e3);
+    }
+
+    // _byzantineLiquid() uses convertToAssets(), not maxWithdraw() — Byzantine's
+    // maxWithdraw liquidity cap does not restrict our vault's maxWithdraw.
+    function test_maxWithdraw_limitedByByzantineLiquidity() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+
+        mockStd.setLiquidityCap(100e6);
+
+        uint256 expected = vaultStd.convertToAssets(vaultStd.balanceOf(user));
+        assertApproxEqAbs(vaultStd.maxWithdraw(user), expected, 1e3);
+    }
+
+    function test_maxWithdraw_zeroWhenNoPosition() public view {
+        assertEq(vaultStd.maxWithdraw(user), 0);
+    }
+
+    // _byzantineLiquid() uses convertToAssets(), not maxWithdraw() — Byzantine's
+    // maxWithdraw liquidity cap does not restrict our vault's maxRedeem.
+    function test_maxRedeem_limitedByByzantineLiquidity() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+
+        mockStd.setLiquidityCap(100e6);
+
+        uint256 maxR = vaultStd.maxRedeem(user);
+        assertApproxEqAbs(maxR, shares, 1e3);
+    }
+
+    function test_maxWithdraw_idleCountsTowardLiquidity() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        uint256 expected = vaultStd.convertToAssets(vaultStd.balanceOf(user));
+        assertApproxEqAbs(vaultStd.maxWithdraw(user), expected, 1e3);
+    }
+
+    function test_maxDeposit_returnsZero_whenPaused() public {
+        vm.prank(guardian);
+        vaultStd.pause();
+        assertEq(vaultStd.maxDeposit(user), 0);
+    }
+}

--- a/test/PaktolVaultV2.permit.t.sol
+++ b/test/PaktolVaultV2.permit.t.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./PaktolVaultV2Base.t.sol";
+
+contract PaktolVaultV2PermitTest is PaktolVaultV2Base {
+
+    address internal permitUser = vm.addr(PERMIT_USER_KEY);
+
+    /* ──────────────────── depositWithPermit ────────────────────────── */
+
+    function test_depositWithPermit_success() public {
+        eurc.mint(permitUser, DEPOSIT);
+
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, PERMIT_USER_KEY, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        uint256 shares = vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+
+        assertGt(shares, 0);
+        assertEq(eurc.balanceOf(permitUser), 0, "EURC spent");
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT, 1e3);
+    }
+
+    function test_depositWithPermit_expiredDeadline() public {
+        eurc.mint(permitUser, DEPOSIT);
+        uint256 deadline = block.timestamp - 1;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, PERMIT_USER_KEY, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        vm.expectRevert();
+        vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+    }
+
+    function test_depositWithPermit_invalidSignature() public {
+        eurc.mint(permitUser, DEPOSIT);
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, 0xBAD, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        vm.expectRevert();
+        vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+    }
+
+    function test_depositWithPermit_tooSmall() public {
+        uint256 tiny = vaultStd.MIN_DEPOSIT() - 1;
+        eurc.mint(permitUser, tiny);
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, PERMIT_USER_KEY, tiny, deadline);
+
+        vm.prank(permitUser);
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.DepositTooSmall.selector, tiny, vaultStd.MIN_DEPOSIT()));
+        vaultStd.depositWithPermit(tiny, permitUser, deadline, v, r, s);
+    }
+
+    function test_depositWithPermit_blockedWhenPaused() public {
+        eurc.mint(permitUser, DEPOSIT);
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, PERMIT_USER_KEY, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        vm.expectRevert();
+        vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+    }
+
+    function test_depositWithPermit_blockedWithoutAccess() public {
+        eurc.mint(permitUser, DEPOSIT);
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultPkt), permitUser, PERMIT_USER_KEY, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVaultV2.PremiumAccessExpired.selector, 0
+        ));
+        vaultPkt.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+    }
+
+    function test_depositWithPermit_successWithAccess() public {
+        eurc.mint(permitUser, DEPOSIT);
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(permitUser, 15 days);
+
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultPkt), permitUser, PERMIT_USER_KEY, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        uint256 shares = vaultPkt.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+        assertGt(shares, 0);
+    }
+
+    /* ─────────────── depositWithPermit — F-13 ──────────────────────── */
+
+    /// @dev F-13: invalid permit + NO pre-existing allowance must revert.
+    function test_f13_invalidPermit_withoutAllowance_reverts() public {
+        eurc.mint(permitUser, DEPOSIT);
+
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, 0xBAD, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        vm.expectRevert(PaktolVaultV2.InsufficientAllowance.selector);
+        vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+    }
+
+    /// @dev F-13: expired permit + NO pre-existing allowance must revert.
+    function test_f13_expiredPermit_withoutAllowance_reverts() public {
+        eurc.mint(permitUser, DEPOSIT);
+
+        uint256 deadline = block.timestamp - 1;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, PERMIT_USER_KEY, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        vm.expectRevert(PaktolVaultV2.InsufficientAllowance.selector);
+        vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+    }
+
+    /// @dev F-13: sufficient pre-existing allowance skips permit entirely — deposit succeeds
+    ///      even with garbage permit params. Documented acceptable behavior: if the user
+    ///      already approved enough, permit is irrelevant.
+    function test_f13_sufficientAllowance_skipsPermit_succeeds() public {
+        eurc.mint(permitUser, DEPOSIT);
+
+        vm.prank(permitUser);
+        eurc.approve(address(vaultStd), DEPOSIT);
+
+        vm.prank(permitUser);
+        uint256 shares = vaultStd.depositWithPermit(DEPOSIT, permitUser, 0, 0, bytes32(0), bytes32(0));
+
+        assertGt(shares, 0);
+    }
+
+    /// @dev F-13: nonce check — permit front-ran (nonce consumed externally) then deposit
+    ///      with that same permit must still work via residual allowance set by front-runner.
+    function test_f13_frontRunPermit_depositsViaResidualAllowance() public {
+        eurc.mint(permitUser, DEPOSIT);
+
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, PERMIT_USER_KEY, DEPOSIT, deadline);
+
+        // Front-runner consumes the permit (sets allowance to vault)
+        vm.prank(address(0xBEEF));
+        IERC20Permit(address(eurc)).permit(permitUser, address(vaultStd), DEPOSIT, deadline, v, r, s);
+
+        // Original depositWithPermit call: permit fails (nonce consumed) but allowance exists
+        vm.prank(permitUser);
+        uint256 shares = vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+
+        assertGt(shares, 0, "should succeed via residual allowance from front-runner");
+    }
+}

--- a/test/PaktolVaultV2.points.t.sol
+++ b/test/PaktolVaultV2.points.t.sol
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./PaktolVaultV2Base.t.sol";
+
+contract PaktolVaultV2PointsTest is PaktolVaultV2Base {
+
+    /* ─────────────────── setPoints ─────────────────────────────────── */
+
+    function test_setPoints_byOwner() public {
+        vm.prank(owner);
+        vaultPkt.setPoints(user, 1000);
+        assertEq(vaultPkt.points(user), 1000);
+    }
+
+    function test_setPoints_revert_unauthorized() public {
+        vm.expectRevert();
+        vm.prank(user);
+        vaultPkt.setPoints(user, 1000);
+    }
+
+    function test_setPoints_revert_zeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.ZeroAddress.selector, "user"));
+        vm.prank(owner);
+        vaultPkt.setPoints(address(0), 1000);
+    }
+
+    function test_setPoints_emitsEvent() public {
+        vm.expectEmit(true, false, false, true);
+        emit PaktolVaultV2.PointsUpdated(user, 1000);
+        vm.prank(owner);
+        vaultPkt.setPoints(user, 1000);
+    }
+
+    function test_setPoints_overwrite() public {
+        vm.startPrank(owner);
+        vaultPkt.setPoints(user, 500);
+        vaultPkt.setPoints(user, 1000);
+        vm.stopPrank();
+        assertEq(vaultPkt.points(user), 1000);
+    }
+
+    /* ─────────────────── setPremiumThreshold ───────────────────────── */
+
+    function test_setPremiumThreshold_byOwner() public {
+        vm.prank(owner);
+        vaultPkt.setPremiumThreshold(500);
+        assertEq(vaultPkt.premiumThreshold(), 500);
+    }
+
+    function test_setPremiumThreshold_revert_unauthorized() public {
+        vm.expectRevert();
+        vm.prank(user);
+        vaultPkt.setPremiumThreshold(500);
+    }
+
+    function test_setPremiumThreshold_emitsEvent() public {
+        vm.expectEmit(false, false, false, true);
+        emit PaktolVaultV2.PremiumThresholdUpdated(PREMIUM_THRESHOLD, 500);
+        vm.prank(owner);
+        vaultPkt.setPremiumThreshold(500);
+    }
+
+    /* ─────────────────── grantPremiumAccess ────────────────────────── */
+
+    function test_grantPremiumAccess_byOwner() public {
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(user, 15 days);
+
+        assertEq(vaultPkt.premiumExpiry(user), block.timestamp + 15 days);
+    }
+
+    function test_grantPremiumAccess_revert_unauthorized() public {
+        vm.expectRevert();
+        vm.prank(user);
+        vaultPkt.grantPremiumAccess(user, 15 days);
+    }
+
+    function test_grantPremiumAccess_revert_zeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.ZeroAddress.selector, "user"));
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(address(0), 15 days);
+    }
+
+    function test_grantPremiumAccess_emitsEvent() public {
+        uint256 expectedExpiry = block.timestamp + 15 days;
+        vm.expectEmit(true, false, false, true);
+        emit PaktolVaultV2.PremiumAccessGranted(user, expectedExpiry);
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(user, 15 days);
+    }
+
+    function test_grantPremiumAccess_renewable() public {
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(user, 15 days);
+
+        _warp(10 days);
+
+        // Renouveler avant expiration — nouveau compteur de 15 jours depuis maintenant.
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(user, 15 days);
+
+        assertEq(vaultPkt.premiumExpiry(user), block.timestamp + 15 days);
+    }
+
+    /* ─────────────── Deposit gating par expiry ─────────────────────── */
+
+    function test_deposit_blocked_withoutAccess() public {
+        eurc.mint(user, DEPOSIT);
+        vm.startPrank(user);
+        eurc.approve(address(vaultPkt), DEPOSIT);
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVaultV2.PremiumAccessExpired.selector, 0
+        ));
+        vaultPkt.deposit(DEPOSIT, user);
+        vm.stopPrank();
+    }
+
+    function test_deposit_success_withActiveAccess() public {
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(user, 15 days);
+
+        uint256 shares = _deposit(vaultPkt, user, DEPOSIT);
+        assertGt(shares, 0);
+        assertApproxEqAbs(vaultPkt.totalAssets(), DEPOSIT, 1e3);
+    }
+
+    function test_deposit_blocked_afterExpiry() public {
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(user, 15 days);
+
+        _deposit(vaultPkt, user, DEPOSIT);
+
+        // Avancer dans le temps après expiration.
+        _warp(16 days);
+
+        eurc.mint(user, DEPOSIT);
+        vm.startPrank(user);
+        eurc.approve(address(vaultPkt), DEPOSIT);
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVaultV2.PremiumAccessExpired.selector,
+            block.timestamp - 1 days  // expiry was 15 days ago
+        ));
+        vaultPkt.deposit(DEPOSIT, user);
+        vm.stopPrank();
+    }
+
+    function test_deposit_allowed_until_last_second() public {
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(user, 15 days);
+
+        // Avancer juste avant l'expiration.
+        _warp(15 days - 1);
+
+        uint256 shares = _deposit(vaultPkt, user, DEPOSIT);
+        assertGt(shares, 0);
+    }
+
+    function test_deposit_blocked_at_exact_expiry() public {
+        uint256 expiry = block.timestamp + 15 days;
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(user, 15 days);
+
+        // Avancer exactement à l'expiration (block.timestamp > expiry → false si ==).
+        _warp(15 days);
+        assertEq(block.timestamp, expiry);
+
+        // block.timestamp == expiry → NOT expired (strict >).
+        uint256 shares = _deposit(vaultPkt, user, DEPOSIT);
+        assertGt(shares, 0);
+    }
+
+    function test_mint_blocked_withoutAccess() public {
+        eurc.mint(user, DEPOSIT);
+        vm.startPrank(user);
+        eurc.approve(address(vaultPkt), DEPOSIT);
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVaultV2.PremiumAccessExpired.selector, 0
+        ));
+        vaultPkt.mint(1e9, user);
+        vm.stopPrank();
+    }
+
+    function test_mint_success_withActiveAccess() public {
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(user, 15 days);
+
+        eurc.mint(user, DEPOSIT);
+        vm.startPrank(user);
+        eurc.approve(address(vaultPkt), DEPOSIT);
+        uint256 assets = vaultPkt.mint(500e9, user);
+        vm.stopPrank();
+
+        assertGt(assets, 0);
+    }
+
+    /* ──────── Standard vault — jamais affecté par l'expiry ─────────── */
+
+    function test_std_vault_ignores_expiry() public {
+        assertEq(vaultStd.premiumExpiry(user), 0);
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+        assertGt(shares, 0);
+    }
+
+    /* ──────── Plusieurs users, accès independants ───────────────────── */
+
+    function test_access_independent_per_user() public {
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(user, 15 days); // user a accès
+
+        // user2 n'a pas d'accès.
+        eurc.mint(user2, DEPOSIT);
+        vm.startPrank(user2);
+        eurc.approve(address(vaultPkt), DEPOSIT);
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVaultV2.PremiumAccessExpired.selector, 0
+        ));
+        vaultPkt.deposit(DEPOSIT, user2);
+        vm.stopPrank();
+
+        // user peut toujours déposer.
+        uint256 shares = _deposit(vaultPkt, user, DEPOSIT);
+        assertGt(shares, 0);
+    }
+
+    /* ──────── Renouvellement — le withdraw reste possible après expiry ── */
+
+    function test_withdraw_still_works_after_expiry() public {
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(user, 15 days);
+
+        uint256 shares = _deposit(vaultPkt, user, DEPOSIT);
+
+        // Access expires — mais le user peut toujours retirer ses fonds.
+        _warp(16 days);
+
+        uint256 balBefore = eurc.balanceOf(user);
+        vm.prank(user);
+        vaultPkt.redeem(shares, user, user);
+
+        assertApproxEqAbs(eurc.balanceOf(user), balBefore + DEPOSIT, 1e3);
+    }
+}

--- a/test/PaktolVaultV2.t.sol
+++ b/test/PaktolVaultV2.t.sol
@@ -1,0 +1,1338 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "../src/PaktolVaultV2.sol";
+
+/* ─────────────────────────────── MOCKS ─────────────────────────────────── */
+
+contract MockEURC is ERC20Permit {
+    constructor() ERC20("Mock EURC", "mEURC") ERC20Permit("Mock EURC") {}
+    function decimals() public pure override returns (uint8) { return 6; }
+    function mint(address to, uint256 amount) external { _mint(to, amount); }
+    function burn(address from, uint256 amount) external { _burn(from, amount); }
+}
+
+/// @dev Minimal ERC-4626. simulateYield mints, simulateLoss burns, setLiquidityCap
+///      limits maxWithdraw to model Morpho liquidity constraints.
+contract MockByzantineVault is ERC4626 {
+    uint256 private _liquidityCap = type(uint256).max;
+
+    constructor(IERC20 asset_) ERC4626(asset_) ERC20("Mock Byzantine", "mBZY") {}
+
+    function simulateYield(uint256 amount) external {
+        MockEURC(asset()).mint(address(this), amount);
+    }
+
+    function simulateLoss(uint256 amount) external {
+        MockEURC(asset()).burn(address(this), amount);
+    }
+
+    function setLiquidityCap(uint256 cap) external {
+        _liquidityCap = cap;
+    }
+
+    function maxWithdraw(address owner_) public view override returns (uint256) {
+        uint256 full = super.maxWithdraw(owner_);
+        return full < _liquidityCap ? full : _liquidityCap;
+    }
+}
+
+/* ─────────────────────────────── TESTS ─────────────────────────────────── */
+
+contract PaktolVaultV2Test is Test {
+    MockEURC             internal eurc;
+    MockByzantineVault   internal mockStd;
+    MockByzantineVault   internal mockPkt;
+    PaktolVaultV2        internal vaultStd;  // Standard — FEE 0.5%, CAP 3.5%, open
+    PaktolVaultV2        internal vaultPkt;  // Premium  — FEE 0.5%, CAP 5%,   auth-gated
+
+    address internal owner     = makeAddr("owner");
+    address internal treasury  = makeAddr("treasury");
+    address internal guardian  = makeAddr("guardian");
+    address internal harvester = makeAddr("harvester");
+    address internal user      = makeAddr("user");
+    address internal user2     = makeAddr("user2");
+
+    uint256 internal constant SIGNER_KEY     = 0xB4C4E3D;
+    uint256 internal constant PERMIT_USER_KEY = 0xA11CE;
+    address internal signer;
+
+    uint256 constant CAP_STD = 350;
+    uint256 constant CAP_PKT = 500;
+    uint256 constant FEE_STD = 50;
+    uint256 constant FEE_PKT = 50;
+
+    uint256 constant DEPOSIT      = 1_000e6;   // 1 000 EURC (6 dec)
+    uint256 constant USER_BALANCE = 10_000e6;
+
+    /* ─────────────────────────── SETUP ─────────────────────────────── */
+
+    function setUp() public {
+        signer  = vm.addr(SIGNER_KEY);
+        eurc    = new MockEURC();
+        mockStd = new MockByzantineVault(IERC20(address(eurc)));
+        mockPkt = new MockByzantineVault(IERC20(address(eurc)));
+
+        vaultStd = new PaktolVaultV2(
+            IERC20(address(eurc)), "Paktol Standard", "pkEURC-S",
+            owner, treasury, CAP_STD, FEE_STD, guardian, harvester,
+            address(mockStd), 0, signer, false
+        );
+        vaultPkt = new PaktolVaultV2(
+            IERC20(address(eurc)), "Paktol Subscription", "pkEURC-P",
+            owner, treasury, CAP_PKT, FEE_PKT, guardian, harvester,
+            address(mockPkt), 0, signer, true
+        );
+
+        eurc.mint(user,  USER_BALANCE);
+        eurc.mint(user2, USER_BALANCE);
+    }
+
+    /* ─────────────────────────── HELPERS ───────────────────────────── */
+
+    function _warp(uint256 delta) internal { vm.warp(block.timestamp + delta); }
+
+    function _deposit(PaktolVaultV2 vault_, address who, uint256 amount) internal returns (uint256 shares) {
+        eurc.mint(who, amount);
+        vm.startPrank(who);
+        eurc.approve(address(vault_), amount);
+        shares = vault_.deposit(amount, who);
+        vm.stopPrank();
+    }
+
+    function _depositWithAuth(
+        PaktolVaultV2 vault_,
+        address who,
+        uint256 amount
+    ) internal returns (uint256 shares) {
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes32 structHash = keccak256(abi.encode(
+            vault_.DEPOSIT_AUTH_TYPEHASH(),
+            who, amount, who, deadline,
+            vault_.nonces(who)
+        ));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", vault_.DOMAIN_SEPARATOR(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_KEY, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        eurc.mint(who, amount);
+        vm.startPrank(who);
+        eurc.approve(address(vault_), amount);
+        shares = vault_.depositWithAuth(amount, who, deadline, sig);
+        vm.stopPrank();
+    }
+
+    function _signPermit(
+        address spender_,
+        address owner_,
+        uint256 ownerKey_,
+        uint256 amount_,
+        uint256 deadline_
+    ) internal view returns (uint8 v, bytes32 r, bytes32 s) {
+        bytes32 PERMIT_TYPEHASH =
+            keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+        bytes32 structHash =
+            keccak256(abi.encode(PERMIT_TYPEHASH, owner_, spender_, amount_, eurc.nonces(owner_), deadline_));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", eurc.DOMAIN_SEPARATOR(), structHash));
+        (v, r, s) = vm.sign(ownerKey_, digest);
+    }
+
+    /* ─────────────────────── CONSTRUCTOR ───────────────────────────── */
+
+    function test_constructor_immutables() public view {
+        assertEq(vaultStd.CAP_BPS(),   CAP_STD);
+        assertEq(vaultStd.FEE_BPS(),   FEE_STD);
+        assertEq(vaultStd.TREASURY(),  treasury);
+        assertEq(address(vaultStd.BYZANTINE_VAULT()), address(mockStd));
+        assertEq(vaultStd.guardian(),  guardian);
+        assertEq(vaultStd.harvester(), harvester);
+        assertEq(vaultStd.SIGNER(),    signer);
+        assertFalse(vaultStd.REQUIRES_AUTH());
+
+        assertEq(vaultPkt.CAP_BPS(), CAP_PKT);
+        assertEq(vaultPkt.FEE_BPS(), FEE_PKT);
+        assertTrue(vaultPkt.REQUIRES_AUTH());
+    }
+
+    function test_constructor_revert_zeroAsset() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.ZeroAddress.selector, "asset"));
+        new PaktolVaultV2(
+            IERC20(address(0)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, harvester, address(mockStd), 0, signer, false
+        );
+    }
+
+    function test_constructor_revert_zeroTreasury() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.ZeroAddress.selector, "treasury"));
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, address(0), CAP_STD, FEE_STD,
+            guardian, harvester, address(mockStd), 0, signer, false
+        );
+    }
+
+    function test_constructor_revert_zeroByzantineVault() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.ZeroAddress.selector, "byzantineVault"));
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, harvester, address(0), 0, signer, false
+        );
+    }
+
+    function test_constructor_revert_assetMismatch() public {
+        MockEURC other = new MockEURC();
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVaultV2.ByzantineVaultAssetMismatch.selector,
+            address(eurc),   // mockStd.asset()
+            address(other)   // expected by PaktolVaultV2
+        ));
+        new PaktolVaultV2(
+            IERC20(address(other)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, harvester, address(mockStd), 0, signer, false
+        );
+    }
+
+    function test_constructor_revert_capZero() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.CapOutOfRange.selector, 0));
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, 0, FEE_STD,
+            guardian, harvester, address(mockStd), 0, signer, false
+        );
+    }
+
+    function test_constructor_revert_capAboveMax() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.CapOutOfRange.selector, 10_001));
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, 10_001, FEE_STD,
+            guardian, harvester, address(mockStd), 0, signer, false
+        );
+    }
+
+    function test_constructor_revert_fee100pct() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.FeeOutOfRange.selector, 10_000));
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, 10_000,
+            guardian, harvester, address(mockStd), 0, signer, false
+        );
+    }
+
+    // F-21: FEE_BPS > FLOOR_BPS causes harvest() DoS — tighten constructor bound.
+    function test_f21_constructor_revert_fee_above_floor_bps() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.FeeOutOfRange.selector, 201));
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, 201,
+            guardian, harvester, address(mockStd), 0, signer, false
+        );
+    }
+
+    function test_f21_constructor_accepts_fee_at_floor_bps() public {
+        PaktolVaultV2 v = new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, 200,
+            guardian, harvester, address(mockStd), 0, signer, false
+        );
+        assertEq(v.FEE_BPS(), 200);
+    }
+
+    // F-14: role separation enforced in constructor.
+    function test_f14_constructor_revert_ownerEqualsGuardian() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            owner, harvester, address(mockStd), 0, signer, false
+        );
+    }
+
+    function test_f14_constructor_revert_ownerEqualsHarvester() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, owner, address(mockStd), 0, signer, false
+        );
+    }
+
+    function test_f14_constructor_revert_guardianEqualsHarvester() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, guardian, address(mockStd), 0, signer, false
+        );
+    }
+
+    /* ───────────────────── DEPOSIT → BYZANTINE ROUTING ─────────────── */
+
+    function test_deposit_basic() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        assertGt(shares, 0);
+        assertEq(vaultStd.totalAssets(), DEPOSIT);
+        assertEq(eurc.balanceOf(address(vaultStd)), 0, "no idle EURC");
+        assertGt(mockStd.balanceOf(address(vaultStd)), 0, "vault holds Byzantine shares");
+    }
+
+    function test_deposit_updates_lastTotalAssets() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        assertEq(vaultStd.lastTotalAssets(), DEPOSIT);
+    }
+
+    function test_deposit_revert_tooSmall() public {
+        uint256 tiny = vaultStd.MIN_DEPOSIT() - 1;
+        eurc.mint(user, tiny);
+        vm.startPrank(user);
+        eurc.approve(address(vaultStd), tiny);
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.DepositTooSmall.selector, tiny, vaultStd.MIN_DEPOSIT()));
+        vaultStd.deposit(tiny, user);
+        vm.stopPrank();
+    }
+
+    function test_deposit_revert_whenPaused() public {
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        vm.startPrank(user);
+        eurc.approve(address(vaultStd), DEPOSIT);
+        vm.expectRevert();
+        vaultStd.deposit(DEPOSIT, user);
+        vm.stopPrank();
+    }
+
+    // F-19: depositUpToCap.
+    function test_f19_depositUpToCap_full_when_under_cap() public {
+        PaktolVaultV2 capped = new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, harvester, address(mockStd), 2_000e6, signer, false
+        );
+        eurc.mint(user, 1_000e6);
+        vm.startPrank(user);
+        eurc.approve(address(capped), 1_000e6);
+        (uint256 accepted, uint256 shares) = capped.depositUpToCap(1_000e6, user);
+        vm.stopPrank();
+
+        assertEq(accepted, 1_000e6, "full amount accepted");
+        assertGt(shares, 0);
+    }
+
+    function test_f19_depositUpToCap_truncates_at_cap() public {
+        uint256 cap = 1_500e6;
+        PaktolVaultV2 capped = new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, harvester, address(mockStd), cap, signer, false
+        );
+        eurc.mint(user, 1_000e6);
+        vm.startPrank(user);
+        eurc.approve(address(capped), 1_000e6);
+        capped.deposit(1_000e6, user);
+        vm.stopPrank();
+
+        _warp(capped.WITHDRAWAL_COOLDOWN());
+
+        eurc.mint(user2, 1_000e6);
+        vm.startPrank(user2);
+        eurc.approve(address(capped), 1_000e6);
+        (uint256 accepted, uint256 shares) = capped.depositUpToCap(1_000e6, user2);
+        vm.stopPrank();
+
+        assertApproxEqAbs(accepted, 500e6, 1e3, "truncated to remaining capacity");
+        assertGt(shares, 0);
+        assertApproxEqAbs(capped.totalAssets(), cap, 1e3, "vault at cap");
+    }
+
+    function test_f19_depositUpToCap_returns_zero_when_full() public {
+        uint256 cap = 1_000e6;
+        PaktolVaultV2 capped = new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, harvester, address(mockStd), cap, signer, false
+        );
+        eurc.mint(user, cap);
+        vm.startPrank(user);
+        eurc.approve(address(capped), cap);
+        capped.deposit(cap, user);
+        vm.stopPrank();
+
+        _warp(capped.WITHDRAWAL_COOLDOWN());
+
+        eurc.mint(user2, 500e6);
+        vm.startPrank(user2);
+        eurc.approve(address(capped), 500e6);
+        (uint256 accepted, uint256 shares) = capped.depositUpToCap(500e6, user2);
+        vm.stopPrank();
+
+        assertEq(accepted, 0, "nothing accepted when cap full");
+        assertEq(shares, 0);
+    }
+
+    function test_f19_deposit_still_reverts_at_cap() public {
+        uint256 cap = 1_000e6;
+        PaktolVaultV2 capped = new PaktolVaultV2(
+            IERC20(address(eurc)), "x", "x", owner, treasury, CAP_STD, FEE_STD,
+            guardian, harvester, address(mockStd), cap, signer, false
+        );
+        eurc.mint(user, cap + 1e6);
+        vm.startPrank(user);
+        eurc.approve(address(capped), cap + 1e6);
+        capped.deposit(cap, user);
+        _warp(capped.WITHDRAWAL_COOLDOWN());
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.TvlCapExceeded.selector, capped.totalAssets(), cap));
+        capped.deposit(1e6, user);
+        vm.stopPrank();
+    }
+
+    /* ────────────────────────── MINT ───────────────────────────────── */
+
+    function test_mint_basic() public {
+        uint256 sharesToMint = 500e9; // 500 share-units (shares have 9 effective decimals)
+        vm.startPrank(user);
+        eurc.approve(address(vaultStd), DEPOSIT);
+        uint256 assetsUsed = vaultStd.mint(sharesToMint, user);
+        vm.stopPrank();
+
+        assertGt(assetsUsed, 0);
+        assertEq(vaultStd.balanceOf(user), sharesToMint);
+        assertEq(eurc.balanceOf(address(vaultStd)), 0, "no idle EURC after mint");
+    }
+
+    /* ────────────────────── WITHDRAW / REDEEM ──────────────────────── */
+
+    function test_withdraw_basic() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+        uint256 balBefore = eurc.balanceOf(user);
+
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT, user, user);
+
+        assertEq(eurc.balanceOf(user), balBefore + DEPOSIT);
+        assertEq(vaultStd.totalAssets(), 0);
+    }
+
+    function test_withdraw_works_when_paused() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        // Cooldown bypassed when paused — must succeed immediately.
+        uint256 balBefore = eurc.balanceOf(user);
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT, user, user);
+
+        assertApproxEqAbs(eurc.balanceOf(user), balBefore + DEPOSIT, 1e3);
+    }
+
+    function test_redeem_basic() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+        uint256 balBefore = eurc.balanceOf(user);
+
+        vm.prank(user);
+        vaultStd.redeem(shares, user, user);
+
+        assertApproxEqAbs(eurc.balanceOf(user), balBefore + DEPOSIT, 1e3);
+        assertApproxEqAbs(vaultStd.totalAssets(), 0, 1e3);
+    }
+
+    function test_withdraw_updates_lastTotalAssets() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT / 2, user, user);
+
+        assertApproxEqAbs(vaultStd.lastTotalAssets(), DEPOSIT / 2, 1e3);
+    }
+
+    /* ─────────────── HARVEST — STANDARD (exact math) ───────────────── */
+
+    function test_harvest_std_belowCap() public {
+        // 20 EURC yield on 1000 = 2% gross, 1 year.
+        // aumFee = 1000 × 0.5% = 5  | flooredFee = 20 × 50/200 = 5 → aumFee = 5
+        // remaining = 15 | maxNetYield = 1000 × 3.5% = 35 → toUsers = 15, toTreasury = 5
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(20e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 expectedFee = (DEPOSIT * FEE_STD) / 10_000; // 5 EURC
+        assertApproxEqAbs(eurc.balanceOf(treasury), expectedFee, 1e3);
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT + 20e6 - expectedFee, 1e3);
+    }
+
+    function test_harvest_std_atCap() public {
+        // 40 EURC yield = 4% gross. aumFee = 5, remaining = 35 = maxNetYield → toTreasury = 5
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(40e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertApproxEqAbs(eurc.balanceOf(treasury), 5e6, 1e3);
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT + 35e6, 1e3);
+    }
+
+    function test_harvest_std_aboveCap() public {
+        // 60 EURC yield = 6% gross.
+        // aumFee = 5, remaining = 55, maxNetYield = 35 → toUsers = 35, toTreasury = 25
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(60e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertApproxEqAbs(eurc.balanceOf(treasury), 25e6, 1e3);
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT + 35e6, 1e3);
+    }
+
+    function test_harvest_std_noYield() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertEq(eurc.balanceOf(treasury), 0);
+        assertEq(vaultStd.totalAssets(), DEPOSIT);
+    }
+
+    function test_harvest_std_loss() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateLoss(100e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest(); // must not revert, no treasury payment
+
+        assertEq(eurc.balanceOf(treasury), 0);
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT - 100e6, 1e3);
+    }
+
+    function test_harvest_std_emitsEvent() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(40e6);
+
+        vm.expectEmit(false, false, false, false);
+        emit PaktolVaultV2.Harvested(0, 0, 0, 0);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+    }
+
+    function test_harvest_std_belowFloor() public {
+        // APY = 1.5% (below 2% floor) — fee is pro-rated down.
+        // grossYield = 15 | flooredFee = 15 × 50/200 = 3.75 < maxAumFee 5 → aumFee = 3.75
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(15e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 expectedFee = (15e6 * 50) / 200; // 3.75 EURC
+        assertApproxEqAbs(eurc.balanceOf(treasury), expectedFee, 1e3);
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT + 15e6 - expectedFee, 1e3);
+    }
+
+    function test_harvest_std_atFloor() public {
+        // APY = 2% exactly — flooredFee == maxAumFee, seamless transition.
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(20e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 expectedFee = (DEPOSIT * FEE_STD) / 10_000; // 5 EURC
+        assertApproxEqAbs(eurc.balanceOf(treasury), expectedFee, 1e3);
+    }
+
+    /* ──────────────────── HARVEST — PREMIUM (FEE=0.5%) ────────────────── */
+
+    function test_harvest_pkt_belowCap() public {
+        // 40 EURC = 4% gross, AUM fee = 5e6, remaining = 35e6 < cap(50e6) → toUsers=35e6, toTreasury=5e6
+        _depositWithAuth(vaultPkt, user, DEPOSIT);
+        _warp(365 days);
+        mockPkt.simulateYield(40e6);
+
+        vm.prank(harvester);
+        vaultPkt.harvest();
+
+        assertApproxEqAbs(eurc.balanceOf(treasury), 5e6, 1e3);
+        assertApproxEqAbs(vaultPkt.totalAssets(), DEPOSIT + 35e6, 1e3);
+    }
+
+    function test_harvest_pkt_atCap() public {
+        // 50 EURC = 5% gross, AUM fee = 5e6, remaining = 45e6 < cap(50e6) → toUsers=45e6, toTreasury=5e6
+        _depositWithAuth(vaultPkt, user, DEPOSIT);
+        _warp(365 days);
+        mockPkt.simulateYield(50e6);
+
+        vm.prank(harvester);
+        vaultPkt.harvest();
+
+        assertApproxEqAbs(eurc.balanceOf(treasury), 5e6, 1e3);
+        assertApproxEqAbs(vaultPkt.totalAssets(), DEPOSIT + 45e6, 1e3);
+    }
+
+    function test_harvest_pkt_aboveCap() public {
+        // 70 EURC = 7% gross, AUM fee = 5e6, remaining = 65e6 > cap(50e6) → toUsers=50e6, toTreasury=20e6
+        _depositWithAuth(vaultPkt, user, DEPOSIT);
+        _warp(365 days);
+        mockPkt.simulateYield(70e6);
+
+        vm.prank(harvester);
+        vaultPkt.harvest();
+
+        assertApproxEqAbs(eurc.balanceOf(treasury), 20e6, 1e3);
+        assertApproxEqAbs(vaultPkt.totalAssets(), DEPOSIT + 50e6, 1e3);
+    }
+
+    /* ─────────────────────── HARVEST GUARDS ────────────────────────── */
+
+    function test_harvest_revert_unauthorized() public {
+        vm.expectRevert(PaktolVaultV2.NotHarvester.selector);
+        vm.prank(user);
+        vaultStd.harvest();
+    }
+
+    function test_harvest_owner_canHarvest() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(40e6);
+
+        vm.prank(owner);
+        vaultStd.harvest();
+
+        assertGt(eurc.balanceOf(treasury), 0);
+    }
+
+    function test_harvest_revert_tooFrequent() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        mockStd.simulateYield(40e6);
+        _warp(vaultStd.MIN_HARVEST_INTERVAL() - 1);
+
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVaultV2.HarvestTooFrequent.selector,
+            vaultStd.MIN_HARVEST_INTERVAL() - 1,
+            vaultStd.MIN_HARVEST_INTERVAL()
+        ));
+        vm.prank(harvester);
+        vaultStd.harvest();
+    }
+
+    function test_harvest_updatesTimestamp() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(7 days);
+        mockStd.simulateYield(10e6);
+
+        uint256 before = vaultStd.lastHarvestTimestamp();
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertGt(vaultStd.lastHarvestTimestamp(), before);
+    }
+
+    /// @dev F-20: no-yield harvest must NOT advance lastHarvestTimestamp.
+    function test_f20_noYield_harvest_preserves_timestamp() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(7 days);
+
+        uint256 tsBefore = vaultStd.lastHarvestTimestamp();
+
+        vm.prank(harvester);
+        vaultStd.harvest(); // no yield → early return
+
+        assertEq(vaultStd.lastHarvestTimestamp(), tsBefore, "timestamp must not advance on no-yield harvest");
+
+        // Real yield accrues later — full elapsed window is preserved.
+        _warp(30 days);
+        mockStd.simulateYield(35e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 elapsed = 37 days;
+        uint256 maxNetYield = (DEPOSIT * 350 * elapsed) / (10_000 * 365 days);
+        assertGe(vaultStd.totalAssets(), DEPOSIT + maxNetYield - 1e3, "full cap window must be applied");
+    }
+
+    /* ─────────── F-18: lastTotalAssets accounting invariant ────────── */
+
+    function test_f18_deposit_does_not_absorb_pending_yield() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        assertEq(vaultStd.lastTotalAssets(), DEPOSIT);
+
+        uint256 yieldAmount = 50e6;
+        mockStd.simulateYield(yieldAmount);
+        // totalAssets = 1050, lastTotalAssets must still be 1000
+
+        uint256 deposit2 = 200e6;
+        _deposit(vaultStd, user2, deposit2);
+
+        // Fix: lastTotalAssets = 1000 + 200 = 1200 (yield gap preserved)
+        // Bug: lastTotalAssets = totalAssets() = 1250 (yield absorbed)
+        assertEq(vaultStd.lastTotalAssets(), DEPOSIT + deposit2, "deposit must not absorb pending yield");
+
+        _warp(365 days);
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertGt(eurc.balanceOf(treasury), 0, "treasury must receive yield from pre-deposit accumulation");
+    }
+
+    function test_f18_withdraw_does_not_absorb_pending_yield() public {
+        _deposit(vaultStd, user,  DEPOSIT);
+        _deposit(vaultStd, user2, DEPOSIT);
+
+        uint256 yieldAmount = 50e6;
+        mockStd.simulateYield(yieldAmount);
+
+        uint256 withdrawAmount = 200e6;
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+        vm.prank(user);
+        vaultStd.withdraw(withdrawAmount, user, user);
+
+        assertEq(vaultStd.lastTotalAssets(), 2 * DEPOSIT - withdrawAmount, "withdraw must not absorb pending yield");
+
+        _warp(365 days);
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertGt(eurc.balanceOf(treasury), 0, "treasury must receive yield from pre-withdrawal accumulation");
+    }
+
+    /* ───────────────────────── FUZZ ────────────────────────────────── */
+
+    function testFuzz_deposit_withdraw_roundtrip(uint256 amount) public {
+        amount = bound(amount, vaultStd.MIN_DEPOSIT(), 1_000_000e6);
+        // _deposit mints internally — no extra mint needed here.
+
+        uint256 shares = _deposit(vaultStd, user, amount);
+        assertApproxEqAbs(vaultStd.totalAssets(), amount, 1e3);
+
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+        vm.prank(user);
+        vaultStd.redeem(shares, user, user);
+
+        assertApproxEqAbs(eurc.balanceOf(user), USER_BALANCE + amount, 1e3);
+    }
+
+    function testFuzz_harvest_std_userNeverExceedsCap(uint256 yieldBps) public {
+        yieldBps = bound(yieldBps, 0, 1_000);
+        uint256 yieldAmount = (DEPOSIT * yieldBps) / 10_000;
+
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        if (yieldAmount > 0) mockStd.simulateYield(yieldAmount);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 userAssets    = vaultStd.convertToAssets(vaultStd.balanceOf(user));
+        uint256 maxUserAssets = DEPOSIT + (DEPOSIT * CAP_STD) / 10_000;
+        assertLe(userAssets, maxUserAssets + 1e3);
+    }
+
+    function testFuzz_harvest_pkt_userNeverExceedsCap(uint256 yieldBps) public {
+        yieldBps = bound(yieldBps, 0, 1_500);
+        uint256 yieldAmount = (DEPOSIT * yieldBps) / 10_000;
+
+        _depositWithAuth(vaultPkt, user, DEPOSIT);
+        _warp(365 days);
+        if (yieldAmount > 0) mockPkt.simulateYield(yieldAmount);
+
+        vm.prank(harvester);
+        vaultPkt.harvest();
+
+        uint256 userAssets    = vaultPkt.convertToAssets(vaultPkt.balanceOf(user));
+        uint256 maxUserAssets = DEPOSIT + (DEPOSIT * CAP_PKT) / 10_000;
+        assertLe(userAssets, maxUserAssets + 1e3);
+    }
+
+    /* ─────────────────── MULTI-USER ────────────────────────────────── */
+
+    function test_multiUser_equalShares() public {
+        uint256 shares1 = _deposit(vaultStd, user,  DEPOSIT);
+        uint256 shares2 = _deposit(vaultStd, user2, DEPOSIT);
+        assertEq(shares1, shares2);
+    }
+
+    function test_multiUser_proportionalYield() public {
+        _deposit(vaultStd, user,  DEPOSIT);
+        _deposit(vaultStd, user2, DEPOSIT);
+
+        _warp(365 days);
+        mockStd.simulateYield(70e6); // 3.5% for each user = 70 total
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 assets1 = vaultStd.convertToAssets(vaultStd.balanceOf(user));
+        uint256 assets2 = vaultStd.convertToAssets(vaultStd.balanceOf(user2));
+
+        assertApproxEqAbs(assets1, assets2, 1e3);
+
+        uint256 aumFee      = (2 * DEPOSIT * FEE_STD) / 10_000; // 10 EURC
+        uint256 expectedNet = (70e6 - aumFee) / 2;
+        assertApproxEqAbs(assets1, DEPOSIT + expectedNet, 1e3);
+    }
+
+    function test_multiUser_laterDepositor_noBackpay() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(35e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 expectedNet = 35e6 - (DEPOSIT * FEE_STD) / 10_000;
+        assertApproxEqAbs(vaultStd.convertToAssets(vaultStd.balanceOf(user)), DEPOSIT + expectedNet, 1e3);
+
+        uint256 shares2 = _deposit(vaultStd, user2, DEPOSIT);
+        assertApproxEqAbs(vaultStd.convertToAssets(shares2), DEPOSIT, 1e3);
+    }
+
+    /* ─────────────── MAX WITHDRAW / REDEEM ─────────────────────────── */
+
+    function test_maxWithdraw_fullLiquidity() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+
+        uint256 expected = vaultStd.convertToAssets(vaultStd.balanceOf(user));
+        assertApproxEqAbs(vaultStd.maxWithdraw(user), expected, 1e3);
+    }
+
+    function test_maxWithdraw_limitedByByzantineLiquidity() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+
+        mockStd.setLiquidityCap(100e6);
+
+        assertApproxEqAbs(vaultStd.maxWithdraw(user), 100e6, 1e3);
+    }
+
+    function test_maxWithdraw_zeroWhenNoPosition() public view {
+        assertEq(vaultStd.maxWithdraw(user), 0);
+    }
+
+    function test_maxRedeem_limitedByByzantineLiquidity() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+
+        mockStd.setLiquidityCap(100e6);
+
+        uint256 maxR = vaultStd.maxRedeem(user);
+        assertLe(maxR, shares);
+        assertApproxEqAbs(vaultStd.convertToAssets(maxR), 100e6, 1e3);
+    }
+
+    function test_maxWithdraw_idleCountsTowardLiquidity() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        // All funds now idle — maxWithdraw should return full position.
+        uint256 expected = vaultStd.convertToAssets(vaultStd.balanceOf(user));
+        assertApproxEqAbs(vaultStd.maxWithdraw(user), expected, 1e3);
+    }
+
+    function test_maxDeposit_returnsZero_whenPaused() public {
+        vm.prank(guardian);
+        vaultStd.pause();
+        assertEq(vaultStd.maxDeposit(user), 0);
+    }
+
+    /* ────────────────────── EMERGENCY EXIT ─────────────────────────── */
+
+    function test_emergencyExit_pullsAllFromByzantine() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        assertGt(mockStd.balanceOf(address(vaultStd)), 0);
+        assertEq(eurc.balanceOf(address(vaultStd)), 0);
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        assertEq(mockStd.balanceOf(address(vaultStd)), 0, "no Byzantine shares after exit");
+        assertApproxEqAbs(eurc.balanceOf(address(vaultStd)), DEPOSIT, 1e3, "idle EURC after exit");
+    }
+
+    function test_emergencyExit_usersCanWithdraw() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        uint256 balBefore = eurc.balanceOf(user);
+        vm.prank(user);
+        vaultStd.redeem(shares, user, user);
+
+        assertApproxEqAbs(eurc.balanceOf(user), balBefore + DEPOSIT, 1e3);
+    }
+
+    function test_emergencyExit_emitsEvent() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.expectEmit(false, false, false, false);
+        emit PaktolVaultV2.EmergencyExitV2(0, 0);
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+    }
+
+    function test_emergencyExit_noOp_whenNoBalance() public {
+        // No deposit — Byzantine shares = 0. Should not revert.
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+    }
+
+    function test_emergencyExit_revert_unauthorized() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.expectRevert();
+        vm.prank(user);
+        vaultStd.emergencyExitByzantine();
+
+        vm.expectRevert();
+        vm.prank(guardian);
+        vaultStd.emergencyExitByzantine();
+    }
+
+    /// @dev F-11: emergencyExitByzantine() must pause atomically.
+    function test_f11_emergencyExit_autopause() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        assertFalse(vaultStd.paused());
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        assertTrue(vaultStd.paused(), "vault must be paused after emergency exit");
+
+        vm.startPrank(user);
+        eurc.approve(address(vaultStd), DEPOSIT);
+        vm.expectRevert();
+        vaultStd.deposit(DEPOSIT, user);
+        vm.stopPrank();
+    }
+
+    /// @dev F-11: emergencyExitByzantine() on an already-paused vault must not revert.
+    function test_f11_emergencyExit_alreadyPaused_noRevert() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        assertTrue(vaultStd.paused());
+        assertEq(mockStd.balanceOf(address(vaultStd)), 0);
+    }
+
+    /// @dev F-11: accounting snapshot after emergency exit is clean.
+    function test_f11_emergencyExit_updatesAccounting() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        mockStd.simulateYield(20e6);
+        _warp(7 days);
+
+        uint256 tsBefore = vaultStd.lastHarvestTimestamp();
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        assertEq(vaultStd.lastTotalAssets(), vaultStd.totalAssets(), "lastTotalAssets must reflect post-exit state");
+        assertGt(vaultStd.lastHarvestTimestamp(), tsBefore, "lastHarvestTimestamp must be reset");
+    }
+
+    /* ─────────────── F-09: WITHDRAWAL COOLDOWN ─────────────────────── */
+
+    function test_f09_cooldown_blocks_immediate_withdraw() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVaultV2.WithdrawalCooldown.selector,
+            block.timestamp + vaultStd.WITHDRAWAL_COOLDOWN()
+        ));
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT, user, user);
+    }
+
+    function test_f09_cooldown_blocks_immediate_redeem() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVaultV2.WithdrawalCooldown.selector,
+            block.timestamp + vaultStd.WITHDRAWAL_COOLDOWN()
+        ));
+        vm.prank(user);
+        vaultStd.redeem(shares, user, user);
+    }
+
+    function test_f09_cooldown_allows_withdraw_after_delay() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+
+        uint256 balBefore = eurc.balanceOf(user);
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT, user, user);
+
+        assertApproxEqAbs(eurc.balanceOf(user), balBefore + DEPOSIT, 1e3);
+    }
+
+    function test_f09_sandwich_blocked_by_cooldown() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(35e6);
+
+        address attacker = address(this);
+        eurc.mint(attacker, DEPOSIT);
+        vm.startPrank(attacker);
+        eurc.approve(address(vaultStd), DEPOSIT);
+        uint256 attackShares = vaultStd.deposit(DEPOSIT, attacker);
+        vm.stopPrank();
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        vm.expectRevert();
+        vm.prank(attacker);
+        vaultStd.redeem(attackShares, attacker, attacker);
+    }
+
+    function test_f09_cooldown_independent_per_user() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+        _deposit(vaultStd, user2, DEPOSIT);
+
+        vm.prank(user);
+        vaultStd.withdraw(DEPOSIT, user, user);
+
+        vm.expectRevert();
+        vm.prank(user2);
+        vaultStd.withdraw(DEPOSIT, user2, user2);
+    }
+
+    function test_f09_cooldown_propagated_on_transfer() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        address attacker2 = makeAddr("attacker2");
+
+        vm.prank(user);
+        vaultStd.transfer(attacker2, shares);
+
+        assertEq(vaultStd.depositTimestamp(attacker2), vaultStd.depositTimestamp(user));
+
+        vm.expectRevert();
+        vm.prank(attacker2);
+        vaultStd.redeem(shares, attacker2, attacker2);
+    }
+
+    function test_f09_cooldown_bypassed_when_paused() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        uint256 balBefore = eurc.balanceOf(user);
+        vm.prank(user);
+        vaultStd.redeem(shares, user, user);
+
+        assertApproxEqAbs(eurc.balanceOf(user), balBefore + DEPOSIT, 1e3);
+    }
+
+    function test_f09_maxWithdraw_zero_during_cooldown() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        assertEq(vaultStd.maxWithdraw(user), 0, "maxWithdraw must be 0 during cooldown");
+        assertEq(vaultStd.maxRedeem(user),   0, "maxRedeem must be 0 during cooldown");
+
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+
+        assertGt(vaultStd.maxWithdraw(user), 0);
+        assertGt(vaultStd.maxRedeem(user),   0);
+    }
+
+    /* ─────────────────── PAUSE / GUARDIAN ──────────────────────────── */
+
+    function test_pause_byGuardian() public {
+        vm.prank(guardian);
+        vaultStd.pause();
+        assertTrue(vaultStd.paused());
+    }
+
+    function test_pause_byOwner() public {
+        vm.prank(owner);
+        vaultStd.pause();
+        assertTrue(vaultStd.paused());
+    }
+
+    function test_pause_revert_unauthorized() public {
+        vm.expectRevert(PaktolVaultV2.NotGuardian.selector);
+        vm.prank(user);
+        vaultStd.pause();
+    }
+
+    function test_unpause_byOwner() public {
+        vm.prank(guardian);
+        vaultStd.pause();
+        vm.prank(owner);
+        vaultStd.unpause();
+        assertFalse(vaultStd.paused());
+    }
+
+    function test_unpause_revert_guardian() public {
+        vm.prank(guardian);
+        vaultStd.pause();
+        vm.expectRevert();
+        vm.prank(guardian);
+        vaultStd.unpause();
+    }
+
+    /* ───────────────────────── ADMIN ───────────────────────────────── */
+
+    function test_setGuardian() public {
+        address newGuardian = makeAddr("newGuardian");
+        vm.prank(owner);
+        vaultStd.setGuardian(newGuardian);
+        assertEq(vaultStd.guardian(), newGuardian);
+    }
+
+    function test_setGuardian_revert_zeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.ZeroAddress.selector, "newGuardian"));
+        vm.prank(owner);
+        vaultStd.setGuardian(address(0));
+    }
+
+    function test_setGuardian_revert_unauthorized() public {
+        vm.expectRevert();
+        vm.prank(user);
+        vaultStd.setGuardian(makeAddr("x"));
+    }
+
+    // F-14: role separation in setGuardian / setHarvester.
+    function test_f14_setGuardian_revert_equalsOwner() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        vm.prank(owner);
+        vaultStd.setGuardian(owner);
+    }
+
+    function test_f14_setGuardian_revert_equalsHarvester() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        vm.prank(owner);
+        vaultStd.setGuardian(harvester);
+    }
+
+    function test_setHarvester() public {
+        address newHarvester = makeAddr("newHarvester");
+        vm.prank(owner);
+        vaultStd.setHarvester(newHarvester);
+        assertEq(vaultStd.harvester(), newHarvester);
+    }
+
+    function test_setHarvester_revert_zeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.ZeroAddress.selector, "newHarvester"));
+        vm.prank(owner);
+        vaultStd.setHarvester(address(0));
+    }
+
+    function test_setHarvester_revert_unauthorized() public {
+        vm.expectRevert();
+        vm.prank(user);
+        vaultStd.setHarvester(makeAddr("x"));
+    }
+
+    function test_f14_setHarvester_revert_equalsOwner() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        vm.prank(owner);
+        vaultStd.setHarvester(owner);
+    }
+
+    function test_f14_setHarvester_revert_equalsGuardian() public {
+        vm.expectRevert(PaktolVaultV2.RolesNotSeparated.selector);
+        vm.prank(owner);
+        vaultStd.setHarvester(guardian);
+    }
+
+    /* ───────────────────── depositWithPermit ───────────────────────── */
+
+    address internal permitUser = vm.addr(PERMIT_USER_KEY);
+
+    function test_depositWithPermit_success() public {
+        eurc.mint(permitUser, DEPOSIT);
+
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, PERMIT_USER_KEY, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        uint256 shares = vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+
+        assertGt(shares, 0);
+        assertEq(eurc.balanceOf(permitUser), 0, "EURC spent");
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT, 1e3);
+    }
+
+    function test_depositWithPermit_expiredDeadline() public {
+        eurc.mint(permitUser, DEPOSIT);
+        uint256 deadline = block.timestamp - 1;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, PERMIT_USER_KEY, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        vm.expectRevert();
+        vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+    }
+
+    function test_depositWithPermit_invalidSignature() public {
+        eurc.mint(permitUser, DEPOSIT);
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, 0xBAD, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        vm.expectRevert();
+        vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+    }
+
+    function test_depositWithPermit_tooSmall() public {
+        uint256 tiny = vaultStd.MIN_DEPOSIT() - 1;
+        eurc.mint(permitUser, tiny);
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, PERMIT_USER_KEY, tiny, deadline);
+
+        vm.prank(permitUser);
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.DepositTooSmall.selector, tiny, vaultStd.MIN_DEPOSIT()));
+        vaultStd.depositWithPermit(tiny, permitUser, deadline, v, r, s);
+    }
+
+    function test_depositWithPermit_blockedWhenPaused() public {
+        eurc.mint(permitUser, DEPOSIT);
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, PERMIT_USER_KEY, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        vm.expectRevert();
+        vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+    }
+
+    function test_depositWithPermit_blockedOnRestrictedVault() public {
+        eurc.mint(permitUser, DEPOSIT);
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultPkt), permitUser, PERMIT_USER_KEY, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        vm.expectRevert(PaktolVaultV2.UseDepositWithAuth.selector);
+        vaultPkt.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+    }
+
+    /* ─────────────────────── depositWithAuth ───────────────────────── */
+
+    function test_depositWithAuth_success() public {
+        uint256 shares = _depositWithAuth(vaultPkt, user, DEPOSIT);
+        assertGt(shares, 0);
+        assertEq(vaultPkt.nonces(user), 1);
+    }
+
+    function test_depositWithAuth_incrementsNonce() public {
+        _depositWithAuth(vaultPkt, user, DEPOSIT);
+        assertEq(vaultPkt.nonces(user), 1);
+        _depositWithAuth(vaultPkt, user, DEPOSIT);
+        assertEq(vaultPkt.nonces(user), 2);
+    }
+
+    function test_depositWithAuth_replayReverts() public {
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes32 structHash = keccak256(abi.encode(
+            vaultPkt.DEPOSIT_AUTH_TYPEHASH(),
+            user, DEPOSIT, user, deadline,
+            vaultPkt.nonces(user)
+        ));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", vaultPkt.DOMAIN_SEPARATOR(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_KEY, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        eurc.mint(user, DEPOSIT * 2);
+        vm.startPrank(user);
+        eurc.approve(address(vaultPkt), DEPOSIT * 2);
+        vaultPkt.depositWithAuth(DEPOSIT, user, deadline, sig);
+        vm.expectRevert(PaktolVaultV2.InvalidSignature.selector);
+        vaultPkt.depositWithAuth(DEPOSIT, user, deadline, sig);
+        vm.stopPrank();
+    }
+
+    function test_depositWithAuth_expiredDeadline() public {
+        uint256 deadline = block.timestamp - 1;
+        bytes32 structHash = keccak256(abi.encode(
+            vaultPkt.DEPOSIT_AUTH_TYPEHASH(),
+            user, DEPOSIT, user, deadline,
+            vaultPkt.nonces(user)
+        ));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", vaultPkt.DOMAIN_SEPARATOR(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_KEY, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        vm.prank(user);
+        vm.expectRevert(PaktolVaultV2.SignatureExpired.selector);
+        vaultPkt.depositWithAuth(DEPOSIT, user, deadline, sig);
+    }
+
+    function test_depositWithAuth_wrongSigner() public {
+        uint256 wrongKey = 0xBADBAD;
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes32 structHash = keccak256(abi.encode(
+            vaultPkt.DEPOSIT_AUTH_TYPEHASH(),
+            user, DEPOSIT, user, deadline,
+            vaultPkt.nonces(user)
+        ));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", vaultPkt.DOMAIN_SEPARATOR(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongKey, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        eurc.mint(user, DEPOSIT);
+        vm.startPrank(user);
+        eurc.approve(address(vaultPkt), DEPOSIT);
+        vm.expectRevert(PaktolVaultV2.InvalidSignature.selector);
+        vaultPkt.depositWithAuth(DEPOSIT, user, deadline, sig);
+        vm.stopPrank();
+    }
+
+    function test_deposit_blockedOnRestrictedVault() public {
+        vm.startPrank(user);
+        eurc.approve(address(vaultPkt), DEPOSIT);
+        vm.expectRevert(PaktolVaultV2.UseDepositWithAuth.selector);
+        vaultPkt.deposit(DEPOSIT, user);
+        vm.stopPrank();
+    }
+
+    function test_mint_blockedOnRestrictedVault() public {
+        vm.startPrank(user);
+        eurc.approve(address(vaultPkt), DEPOSIT);
+        vm.expectRevert(PaktolVaultV2.UseDepositWithAuth.selector);
+        vaultPkt.mint(1e9, user);
+        vm.stopPrank();
+    }
+
+    /* ─────────────── totalAssets reflects Byzantine yield ──────────── */
+
+    function test_totalAssets_reflectsYield() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        uint256 before = vaultStd.totalAssets();
+
+        mockStd.simulateYield(500e6);
+
+        assertGt(vaultStd.totalAssets(), before);
+    }
+}

--- a/test/PaktolVaultV2.t.sol
+++ b/test/PaktolVaultV2.t.sol
@@ -1238,6 +1238,67 @@ contract PaktolVaultV2Test is Test {
         vaultPkt.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
     }
 
+    /* ───────────────── depositWithPermit — F-13 ────────────────────── */
+
+    /// @dev F-13: invalid permit + NO pre-existing allowance must revert.
+    function test_f13_invalidPermit_withoutAllowance_reverts() public {
+        eurc.mint(permitUser, DEPOSIT);
+
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, 0xBAD, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        vm.expectRevert(PaktolVaultV2.InsufficientAllowance.selector);
+        vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+    }
+
+    /// @dev F-13: expired permit + NO pre-existing allowance must revert.
+    function test_f13_expiredPermit_withoutAllowance_reverts() public {
+        eurc.mint(permitUser, DEPOSIT);
+
+        uint256 deadline = block.timestamp - 1;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, PERMIT_USER_KEY, DEPOSIT, deadline);
+
+        vm.prank(permitUser);
+        vm.expectRevert(PaktolVaultV2.InsufficientAllowance.selector);
+        vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+    }
+
+    /// @dev F-13: sufficient pre-existing allowance skips permit entirely — deposit succeeds
+    ///      even with garbage permit params. Documented acceptable behavior: if the user
+    ///      already approved enough, permit is irrelevant.
+    function test_f13_sufficientAllowance_skipsPermit_succeeds() public {
+        eurc.mint(permitUser, DEPOSIT);
+
+        vm.prank(permitUser);
+        eurc.approve(address(vaultStd), DEPOSIT);
+
+        // Garbage permit params are ignored since allowance is already sufficient
+        vm.prank(permitUser);
+        uint256 shares = vaultStd.depositWithPermit(DEPOSIT, permitUser, 0, 0, bytes32(0), bytes32(0));
+
+        assertGt(shares, 0);
+    }
+
+    /// @dev F-13: nonce check — permit front-ran (nonce consumed externally) then deposit
+    ///      with that same permit must still work via residual allowance set by front-runner.
+    function test_f13_frontRunPermit_depositsViaResidualAllowance() public {
+        eurc.mint(permitUser, DEPOSIT);
+
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(vaultStd), permitUser, PERMIT_USER_KEY, DEPOSIT, deadline);
+
+        // Front-runner consumes the permit (sets allowance to vault)
+        vm.prank(address(0xBEEF));
+        IERC20Permit(address(eurc)).permit(permitUser, address(vaultStd), DEPOSIT, deadline, v, r, s);
+
+        // Original depositWithPermit call: permit fails (nonce consumed) but allowance exists
+        vm.prank(permitUser);
+        uint256 shares = vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+
+        assertGt(shares, 0, "should succeed via residual allowance from front-runner");
+    }
+
     /* ─────────────────────── depositWithAuth ───────────────────────── */
 
     function test_depositWithAuth_success() public {

--- a/test/PaktolVaultV2.treasury.t.sol
+++ b/test/PaktolVaultV2.treasury.t.sol
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./PaktolVaultV2Base.t.sol";
+
+contract PaktolVaultV2TreasuryTest is PaktolVaultV2Base {
+
+    /* ──────────── Treasury shares compound between harvests ─────────── */
+
+    function test_treasury_shares_compound_between_harvests() public {
+        // Harvest 1 — treasury receives shares worth ~5 EURC fee.
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(20e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 treasuryValueAfterHarvest1 = vaultStd.convertToAssets(vaultStd.balanceOf(treasury));
+        assertGt(treasuryValueAfterHarvest1, 0, "treasury must hold shares after harvest 1");
+
+        // Morpho generates more yield — treasury shares appreciate without any action.
+        _warp(365 days);
+        mockStd.simulateYield(20e6);
+
+        uint256 treasuryValueMidway = vaultStd.convertToAssets(vaultStd.balanceOf(treasury));
+        assertGt(
+            treasuryValueMidway,
+            treasuryValueAfterHarvest1,
+            "treasury shares must grow with Morpho yield between harvests"
+        );
+
+        // Harvest 2 — treasury receives additional shares on top of already-grown position.
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 treasuryValueAfterHarvest2 = vaultStd.convertToAssets(vaultStd.balanceOf(treasury));
+        assertGt(
+            treasuryValueAfterHarvest2,
+            treasuryValueMidway,
+            "harvest 2 must add more shares to treasury"
+        );
+
+        // Treasury can redeem all its shares for real EURC at any time.
+        uint256 treasuryShares = vaultStd.balanceOf(treasury);
+        _warp(vaultStd.WITHDRAWAL_COOLDOWN());
+        vm.prank(treasury);
+        vaultStd.redeem(treasuryShares, treasury, treasury);
+
+        assertApproxEqAbs(
+            eurc.balanceOf(treasury),
+            treasuryValueAfterHarvest2,
+            1e3,
+            "treasury must receive EURC equal to compounded share value"
+        );
+        assertEq(vaultStd.balanceOf(treasury), 0, "treasury shares fully redeemed");
+    }
+
+    /* ──────────── lastTreasuryAssets snapshot — timing fix ─────────── */
+
+    function test_lastTreasuryAssets_updated_after_harvest() public {
+        assertEq(vaultStd.lastTreasuryAssets(), 0);
+
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(20e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 treasuryValue = vaultStd.convertToAssets(vaultStd.balanceOf(treasury));
+        assertEq(
+            vaultStd.lastTreasuryAssets(),
+            treasuryValue,
+            "lastTreasuryAssets must equal treasury share value post-harvest"
+        );
+    }
+
+    function test_userAssets_uses_snapshot_not_current_value() public {
+        // Harvest 1 — treasury gets shares, lastTreasuryAssets snapshot set.
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(20e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 snapshotAfterH1 = vaultStd.lastTreasuryAssets();
+        assertGt(snapshotAfterH1, 0);
+
+        // Morpho generates more yield — treasury shares appreciate.
+        _warp(365 days);
+        mockStd.simulateYield(20e6);
+
+        uint256 currentTreasuryValue = vaultStd.convertToAssets(vaultStd.balanceOf(treasury));
+        assertGt(currentTreasuryValue, snapshotAfterH1, "treasury must have grown");
+
+        // Harvest 2 — userAssets computed from lastTreasuryAssets (snapshot), not current.
+        uint256 userAssetsExpected = vaultStd.lastTotalAssets() - snapshotAfterH1;
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        assertGt(
+            vaultStd.lastTreasuryAssets(),
+            snapshotAfterH1,
+            "snapshot must advance to current treasury value after harvest 2"
+        );
+
+        // User was not over-penalised — cap based on correct userAssets.
+        uint256 userValue = vaultStd.convertToAssets(vaultStd.balanceOf(user));
+        assertGt(userValue, DEPOSIT, "user must have received yield");
+        uint256 maxAllowed = DEPOSIT + (userAssetsExpected * CAP_STD * 365 days) / (10_000 * 365 days) + 1e3;
+        assertLe(userValue, maxAllowed + 1e3, "user must not exceed cap");
+    }
+
+    function test_flooredFee_uses_user_yield_not_gross() public {
+        // Harvest 1 — seed treasury with shares (at-cap scenario).
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(40e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 treasurySharesH1 = vaultStd.balanceOf(treasury);
+        assertGt(treasurySharesH1, 0, "treasury must have shares after H1");
+
+        uint256 userAssets_ = vaultStd.lastTotalAssets() - vaultStd.lastTreasuryAssets();
+        uint256 totalPool_  = vaultStd.lastTotalAssets();
+
+        // Harvest 2 — below-floor yield (1% APY).
+        _warp(365 days);
+        uint256 belowFloorYield = 10e6;
+        mockStd.simulateYield(belowFloorYield);
+
+        // Expected fee using userYield (correct implementation).
+        uint256 userYield_  = belowFloorYield * userAssets_ / totalPool_;
+        uint256 expectedFee = userYield_ * FEE_STD / 200;
+
+        // What fee would be using grossYield (wrong implementation).
+        uint256 wrongFee = belowFloorYield * FEE_STD / 200;
+
+        assertLt(userYield_, belowFloorYield, "userYield must be less than grossYield");
+        assertLt(expectedFee, wrongFee,       "correct fee must be less than grossYield-based fee");
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 newShares     = vaultStd.balanceOf(treasury) - treasurySharesH1;
+        uint256 newShareValue = vaultStd.convertToAssets(newShares);
+
+        assertApproxEqAbs(newShareValue, expectedFee, 1e4, "H2 fee must be based on userYield");
+        assertGt(wrongFee - newShareValue, 0,               "H2 fee must be less than grossYield-based fee");
+    }
+
+    /* ──────── H-1: lastTreasuryAssets synced on loss harvest ───────── */
+
+    /// @dev After a Morpho loss, lastTreasuryAssets must scale down with lastTotalAssets
+    ///      so that userAssets is not zero on recovery and user yield is not stolen.
+    function test_h1_loss_harvest_syncs_lastTreasuryAssets() public {
+        // Harvest 1 — treasury gets shares worth ~5 EURC.
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(20e6);
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 treasuryValueAfterH1 = vaultStd.lastTreasuryAssets();
+        assertGt(treasuryValueAfterH1, 0);
+
+        // Morpho suffers a loss — TVL drops below lastTotalAssets.
+        _warp(7 days);
+        mockStd.simulateLoss(500e6); // vault now underwater
+
+        vm.prank(harvester);
+        vaultStd.harvest(); // no-yield branch
+
+        // lastTreasuryAssets must be re-synced to current treasury share value.
+        uint256 currentTreasuryValue = vaultStd.convertToAssets(vaultStd.balanceOf(treasury));
+        assertEq(
+            vaultStd.lastTreasuryAssets(),
+            currentTreasuryValue,
+            "lastTreasuryAssets must be synced after loss harvest"
+        );
+
+        // userAssets must be positive — not zeroed by stale snapshot.
+        uint256 userAssets = vaultStd.lastTotalAssets() > vaultStd.lastTreasuryAssets()
+            ? vaultStd.lastTotalAssets() - vaultStd.lastTreasuryAssets()
+            : 0;
+        assertGt(userAssets, 0, "userAssets must remain positive after loss, not zeroed by stale snapshot");
+    }
+
+    /// @dev On recovery after loss, user yield must not go entirely to treasury.
+    function test_h1_recovery_yield_goes_to_users() public {
+        // Harvest 1 — seed treasury shares.
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(20e6);
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        // Loss — then loss-harvest to sync snapshot.
+        _warp(7 days);
+        mockStd.simulateLoss(200e6);
+        vm.prank(harvester);
+        vaultStd.harvest(); // no-yield branch, syncs lastTreasuryAssets
+
+        uint256 userValueBeforeRecovery = vaultStd.convertToAssets(vaultStd.balanceOf(user));
+
+        // Recovery yield.
+        _warp(365 days);
+        mockStd.simulateYield(30e6);
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 userValueAfterRecovery = vaultStd.convertToAssets(vaultStd.balanceOf(user));
+
+        assertGt(
+            userValueAfterRecovery,
+            userValueBeforeRecovery,
+            "user must receive recovery yield, not stolen by treasury due to stale snapshot"
+        );
+    }
+
+    /* ───────────────── L-2: treasury cooldown exemption ────────────── */
+
+    /// @dev Treasury receives shares via harvest (no depositTimestamp set).
+    ///      It must be able to redeem immediately — no 4h cooldown.
+    function test_l2_treasury_redeem_immediate_after_harvest() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(365 days);
+        mockStd.simulateYield(20e6);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        uint256 treasuryShares = vaultStd.balanceOf(treasury);
+        assertGt(treasuryShares, 0, "treasury must hold shares");
+
+        // No time warp — treasury should be able to redeem at t=0 after harvest.
+        assertGt(vaultStd.maxRedeem(treasury), 0, "treasury maxRedeem must be > 0 immediately");
+
+        uint256 balBefore = eurc.balanceOf(treasury);
+        vm.prank(treasury);
+        vaultStd.redeem(treasuryShares, treasury, treasury);
+
+        assertGt(eurc.balanceOf(treasury), balBefore, "treasury must receive EURC immediately");
+    }
+
+    /// @dev Regular user is still subject to the 4h cooldown.
+    function test_l2_user_cooldown_still_enforced() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        // Immediately after deposit — maxRedeem must be 0.
+        assertEq(vaultStd.maxRedeem(user), 0, "user must be locked within 4h cooldown");
+    }
+}

--- a/test/PaktolVaultV2Base.t.sol
+++ b/test/PaktolVaultV2Base.t.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "../src/PaktolVaultV2.sol";
+
+/* ─────────────────────────────── MOCKS ─────────────────────────────────── */
+
+contract MockEURC is ERC20Permit {
+    constructor() ERC20("Mock EURC", "mEURC") ERC20Permit("Mock EURC") {}
+    function decimals() public pure override returns (uint8) { return 6; }
+    function mint(address to, uint256 amount) external { _mint(to, amount); }
+    function burn(address from, uint256 amount) external { _burn(from, amount); }
+}
+
+/// @dev Minimal ERC-4626. simulateYield mints, simulateLoss burns, setLiquidityCap
+///      limits maxWithdraw to model Morpho liquidity constraints.
+contract MockByzantineVault is ERC4626 {
+    uint256 private _liquidityCap = type(uint256).max;
+
+    constructor(IERC20 asset_) ERC4626(asset_) ERC20("Mock Byzantine", "mBZY") {}
+
+    function simulateYield(uint256 amount) external {
+        MockEURC(asset()).mint(address(this), amount);
+    }
+
+    function simulateLoss(uint256 amount) external {
+        MockEURC(asset()).burn(address(this), amount);
+    }
+
+    function setLiquidityCap(uint256 cap) external {
+        _liquidityCap = cap;
+    }
+
+    function maxWithdraw(address owner_) public view override returns (uint256) {
+        uint256 full = super.maxWithdraw(owner_);
+        return full < _liquidityCap ? full : _liquidityCap;
+    }
+}
+
+/* ─────────────────────────────── BASE ──────────────────────────────────── */
+
+contract PaktolVaultV2Base is Test {
+    MockEURC             internal eurc;
+    MockByzantineVault   internal mockStd;
+    MockByzantineVault   internal mockPkt;
+    PaktolVaultV2        internal vaultStd;  // Standard — FEE 0.5%, CAP 3.5%, open
+    PaktolVaultV2        internal vaultPkt;  // Premium  — FEE 0.5%, CAP 5%, points-gated
+
+    address internal owner     = makeAddr("owner");
+    address internal treasury  = makeAddr("treasury");
+    address internal guardian  = makeAddr("guardian");
+    address internal harvester = makeAddr("harvester");
+    address internal user      = makeAddr("user");
+    address internal user2     = makeAddr("user2");
+
+    uint256 internal constant PERMIT_USER_KEY = 0xA11CE;
+
+    uint256 constant CAP_STD = 350;
+    uint256 constant CAP_PKT = 500;
+    uint256 constant FEE_STD = 50;
+    uint256 constant FEE_PKT = 50;
+
+    uint256 constant PREMIUM_THRESHOLD = 100;
+
+    uint256 constant DEPOSIT      = 1_000e6;
+    uint256 constant USER_BALANCE = 10_000e6;
+
+    function setUp() public virtual {
+        eurc    = new MockEURC();
+        mockStd = new MockByzantineVault(IERC20(address(eurc)));
+        mockPkt = new MockByzantineVault(IERC20(address(eurc)));
+
+        vaultStd = new PaktolVaultV2(
+            IERC20(address(eurc)), "Paktol Standard", "pkEURC-S",
+            owner, treasury, CAP_STD, FEE_STD, guardian, harvester,
+            address(mockStd), 0, 0, false
+        );
+        vaultPkt = new PaktolVaultV2(
+            IERC20(address(eurc)), "Paktol Subscription", "pkEURC-P",
+            owner, treasury, CAP_PKT, FEE_PKT, guardian, harvester,
+            address(mockPkt), 0, PREMIUM_THRESHOLD, true
+        );
+
+        eurc.mint(user,  USER_BALANCE);
+        eurc.mint(user2, USER_BALANCE);
+    }
+
+    function _warp(uint256 delta) internal { vm.warp(block.timestamp + delta); }
+
+    function _deposit(PaktolVaultV2 vault_, address who, uint256 amount) internal returns (uint256 shares) {
+        eurc.mint(who, amount);
+        vm.startPrank(who);
+        eurc.approve(address(vault_), amount);
+        shares = vault_.deposit(amount, who);
+        vm.stopPrank();
+    }
+
+    /// @dev Grant 15-day premium access then deposit into vaultPkt.
+    function _depositPremium(address who, uint256 amount) internal returns (uint256 shares) {
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(who, 15 days);
+        shares = _deposit(vaultPkt, who, amount);
+    }
+
+    function _signPermit(
+        address spender_,
+        address owner_,
+        uint256 ownerKey_,
+        uint256 amount_,
+        uint256 deadline_
+    ) internal view returns (uint8 v, bytes32 r, bytes32 s) {
+        bytes32 PERMIT_TYPEHASH =
+            keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+        bytes32 structHash =
+            keccak256(abi.encode(PERMIT_TYPEHASH, owner_, spender_, amount_, eurc.nonces(owner_), deadline_));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", eurc.DOMAIN_SEPARATOR(), structHash));
+        (v, r, s) = vm.sign(ownerKey_, digest);
+    }
+}

--- a/test/PaktolVaultV2ForkBase.t.sol
+++ b/test/PaktolVaultV2ForkBase.t.sol
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../src/PaktolVaultV2.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+
+/// @dev Fork tests against the real Byzantine EUR Sandbox vault on Base Mainnet.
+///      Run with:
+///        forge test --match-contract "ForkBase" --fork-url https://mainnet.base.org -vvv
+///
+///      No gas cost — everything runs in a local fork.
+contract PaktolVaultV2ForkBaseTest is Test {
+
+    /* ─────────────── Base Mainnet constants ────────────────────────── */
+
+    address constant EURC_BASE     = 0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42;
+    address constant BYZANTINE_EUR = 0x7aA6B0aff73E3E0416CdfCD64F51E5cFa910ad01;
+
+    /* ─────────────── Roles ─────────────────────────────────────────── */
+
+    address internal owner     = makeAddr("owner");
+    address internal treasury  = makeAddr("treasury");
+    address internal guardian  = makeAddr("guardian");
+    address internal harvester = makeAddr("harvester");
+    address internal user      = makeAddr("user");
+    address internal user2     = makeAddr("user2");
+
+    uint256 internal constant PERMIT_USER_KEY = 0xA11CE;
+    address internal permitUser = vm.addr(PERMIT_USER_KEY);
+
+    /* ─────────────── Vault params ──────────────────────────────────── */
+
+    uint256 constant CAP_BPS = 350;  // 3.5%
+    uint256 constant FEE_BPS = 50;   // 0.5%
+    uint256 constant DEPOSIT = 100e6; // 100 EURC
+
+    /* ─────────────── Vault instances ──────────────────────────────── */
+
+    PaktolVaultV2 internal vaultStd;  // open vault
+    PaktolVaultV2 internal vaultPkt;  // premium-gated vault
+
+    /* ─────────────── setUp ─────────────────────────────────────────── */
+
+    function setUp() public {
+        // Fork is provided via --fork-url flag; verify we're on Base.
+        assertEq(block.chainid, 8453, "must fork Base Mainnet (use --fork-url https://mainnet.base.org)");
+        assertEq(IERC4626(BYZANTINE_EUR).asset(), EURC_BASE, "Byzantine asset mismatch");
+
+        // Deploy both vaults
+        vaultStd = new PaktolVaultV2(
+            IERC20(EURC_BASE),
+            "Paktol Standard EURC",  "pkEURC-S",
+            owner, treasury, CAP_BPS, FEE_BPS,
+            guardian, harvester,
+            BYZANTINE_EUR,
+            0, 0, false            // no TVL cap, no threshold, open
+        );
+
+        vaultPkt = new PaktolVaultV2(
+            IERC20(EURC_BASE),
+            "Paktol Premium EURC",  "pkEURC-P",
+            owner, treasury, CAP_BPS, FEE_BPS,
+            guardian, harvester,
+            BYZANTINE_EUR,
+            0, 100, true           // no TVL cap, threshold=100, gated
+        );
+
+        // Fund users with real EURC via deal() (modifies storage slot directly)
+        deal(EURC_BASE, user,       10_000e6);
+        deal(EURC_BASE, user2,      10_000e6);
+        deal(EURC_BASE, permitUser, 10_000e6);
+
+        // Seed dead shares on both vaults to prevent inflation attacks
+        _seed(vaultStd);
+        _seed(vaultPkt);
+    }
+
+    /* ─────────────── helpers ───────────────────────────────────────── */
+
+    function _seed(PaktolVaultV2 vault_) internal {
+        uint256 min = vault_.MIN_DEPOSIT();
+        deal(EURC_BASE, owner, min);
+        vm.startPrank(owner);
+        if (vault_.REQUIRES_AUTH()) vault_.grantPremiumAccess(address(0xdEaD), 365 days);
+        IERC20(EURC_BASE).approve(address(vault_), min);
+        vault_.deposit(min, address(0xdEaD));
+        vm.stopPrank();
+    }
+
+    function _deposit(PaktolVaultV2 vault_, address who, uint256 amount) internal returns (uint256) {
+        deal(EURC_BASE, who, amount);
+        vm.startPrank(who);
+        IERC20(EURC_BASE).approve(address(vault_), amount);
+        uint256 shares = vault_.deposit(amount, who);
+        vm.stopPrank();
+        return shares;
+    }
+
+    function _warp(uint256 delta) internal { vm.warp(block.timestamp + delta); }
+
+    /* ══════════════════════════════════════════════════════════════════
+       1. DEPLOYMENT & WIRING
+       ══════════════════════════════════════════════════════════════════ */
+
+    function test_fork_base_config() public view {
+        assertEq(address(vaultStd.asset()), EURC_BASE);
+        assertEq(address(vaultStd.BYZANTINE_VAULT()), BYZANTINE_EUR);
+        assertEq(vaultStd.owner(), owner);
+        assertEq(vaultStd.TREASURY(), treasury);
+        assertFalse(vaultStd.REQUIRES_AUTH());
+        assertTrue(vaultPkt.REQUIRES_AUTH());
+    }
+
+    /* ══════════════════════════════════════════════════════════════════
+       2. DEPOSIT → BYZANTINE ROUTING
+       ══════════════════════════════════════════════════════════════════ */
+
+    function test_fork_base_deposit_routes_to_byzantine() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+        uint256 min = vaultStd.MIN_DEPOSIT();
+
+        assertGt(shares, 0, "vault shares minted");
+        // totalAssets counts idle EURC + Byzantine position — correct either way.
+        // On sandbox, maxDeposit()=0 (no supply queue) so EURC may stay idle.
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT + min, 1e3, "totalAssets correct");
+        // All funds accounted for (idle + Byzantine)
+        uint256 idle   = IERC20(EURC_BASE).balanceOf(address(vaultStd));
+        uint256 bShares = IERC4626(BYZANTINE_EUR).balanceOf(address(vaultStd));
+        uint256 bVal   = bShares > 0 ? IERC4626(BYZANTINE_EUR).convertToAssets(bShares) : 0;
+        assertApproxEqAbs(idle + bVal, DEPOSIT + min, 1e3, "no funds lost");
+    }
+
+    function test_fork_base_totalAssets_reflects_byzantine() public {
+        uint256 min = vaultStd.MIN_DEPOSIT();
+        uint256 expected = DEPOSIT + min; // user + dead shares
+
+        _deposit(vaultStd, user, DEPOSIT);
+
+        // totalAssets includes idle EURC + Byzantine position — correct on sandbox and prod.
+        assertApproxEqAbs(vaultStd.totalAssets(), expected, 1e3, "totalAssets correct");
+    }
+
+    /* ══════════════════════════════════════════════════════════════════
+       3. WITHDRAW ROUNDTRIP
+       ══════════════════════════════════════════════════════════════════ */
+
+    function test_fork_base_redeem_roundtrip() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+        uint256 balBefore = IERC20(EURC_BASE).balanceOf(user);
+
+        // Wait out cooldown
+        _warp(5 hours);
+
+        vm.prank(user);
+        uint256 received = vaultStd.redeem(shares, user, user);
+
+        assertApproxEqAbs(received, DEPOSIT, 1e3, "user gets back deposit");
+        assertGt(IERC20(EURC_BASE).balanceOf(user), balBefore, "user EURC balance increased");
+    }
+
+    function test_fork_base_withdraw_blocked_in_cooldown() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        // Immediately after deposit — maxWithdraw must be 0
+        assertEq(vaultStd.maxWithdraw(user), 0, "locked in cooldown");
+        assertEq(vaultStd.maxRedeem(user), 0, "locked in cooldown");
+    }
+
+    function test_fork_base_withdraw_available_after_cooldown() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(5 hours);
+
+        assertGt(vaultStd.maxWithdraw(user), 0, "unlocked after cooldown");
+    }
+
+    /* ══════════════════════════════════════════════════════════════════
+       4. HARVEST
+       ══════════════════════════════════════════════════════════════════ */
+
+    /// @dev Harvest callable after MIN_HARVEST_INTERVAL (1 day). May emit HarvestSkipped
+    ///      on sandbox (no Morpho markets), but must not revert.
+    function test_fork_base_harvest_callable_after_interval() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(2 days);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+    }
+
+    function test_fork_base_harvest_blocked_when_paused() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(2 days);
+
+        vm.prank(guardian);
+        vaultStd.pause();
+
+        vm.prank(harvester);
+        vm.expectRevert();
+        vaultStd.harvest();
+    }
+
+    function test_fork_base_harvest_revert_before_interval() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        // No warp — elapsed = 0 < MIN_HARVEST_INTERVAL → must revert
+        vm.prank(harvester);
+        vm.expectRevert();
+        vaultStd.harvest();
+    }
+
+    /// @dev After a successful harvest (yield found, lastHarvestTimestamp updated),
+    ///      a second call within 1 day must revert HarvestTooFrequent.
+    function test_fork_base_harvest_too_frequent_after_success() public {
+        _deposit(vaultStd, user, DEPOSIT);
+        _warp(2 days);
+
+        vm.prank(harvester);
+        vaultStd.harvest();
+
+        // Only test too-frequent if the first harvest was successful (not skipped).
+        // HarvestSkipped does NOT update lastHarvestTimestamp by design.
+        if (vaultStd.lastHarvestTimestamp() == block.timestamp) {
+            vm.prank(harvester);
+            vm.expectRevert(abi.encodeWithSelector(
+                PaktolVaultV2.HarvestTooFrequent.selector,
+                0,
+                vaultStd.MIN_HARVEST_INTERVAL()
+            ));
+            vaultStd.harvest();
+        }
+    }
+
+    /* ══════════════════════════════════════════════════════════════════
+       5. PREMIUM ACCESS (vaultPkt)
+       ══════════════════════════════════════════════════════════════════ */
+
+    function test_fork_base_pkt_blocked_without_access() public {
+        deal(EURC_BASE, user, DEPOSIT);
+        vm.startPrank(user);
+        IERC20(EURC_BASE).approve(address(vaultPkt), DEPOSIT);
+        vm.expectRevert(abi.encodeWithSelector(PaktolVaultV2.PremiumAccessExpired.selector, 0));
+        vaultPkt.deposit(DEPOSIT, user);
+        vm.stopPrank();
+    }
+
+    function test_fork_base_pkt_deposit_with_access() public {
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(user, 15 days);
+
+        uint256 shares = _deposit(vaultPkt, user, DEPOSIT);
+        assertGt(shares, 0, "shares minted");
+        assertApproxEqAbs(vaultPkt.totalAssets(), DEPOSIT + vaultPkt.MIN_DEPOSIT(), 1e3, "totalAssets correct");
+    }
+
+    function test_fork_base_pkt_access_expires() public {
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(user, 15 days);
+
+        _deposit(vaultPkt, user, DEPOSIT);
+        _warp(16 days);
+
+        deal(EURC_BASE, user, DEPOSIT);
+        vm.startPrank(user);
+        IERC20(EURC_BASE).approve(address(vaultPkt), DEPOSIT);
+        vm.expectRevert(abi.encodeWithSelector(
+            PaktolVaultV2.PremiumAccessExpired.selector,
+            block.timestamp - 1 days
+        ));
+        vaultPkt.deposit(DEPOSIT, user);
+        vm.stopPrank();
+    }
+
+    function test_fork_base_pkt_withdraw_after_expiry() public {
+        vm.prank(owner);
+        vaultPkt.grantPremiumAccess(user, 15 days);
+
+        uint256 shares = _deposit(vaultPkt, user, DEPOSIT);
+        _warp(16 days); // access expired + cooldown passed
+
+        uint256 balBefore = IERC20(EURC_BASE).balanceOf(user);
+        vm.prank(user);
+        vaultPkt.redeem(shares, user, user);
+
+        assertApproxEqAbs(IERC20(EURC_BASE).balanceOf(user), balBefore + DEPOSIT, 1e3);
+    }
+
+    /* ══════════════════════════════════════════════════════════════════
+       6. DEPOSIT WITH PERMIT
+       ══════════════════════════════════════════════════════════════════ */
+
+    function test_fork_base_depositWithPermit() public {
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(
+            address(vaultStd), permitUser, PERMIT_USER_KEY, DEPOSIT, deadline
+        );
+
+        vm.prank(permitUser);
+        uint256 shares = vaultStd.depositWithPermit(DEPOSIT, permitUser, deadline, v, r, s);
+
+        assertGt(shares, 0, "shares minted");
+        assertApproxEqAbs(vaultStd.totalAssets(), DEPOSIT + vaultStd.MIN_DEPOSIT(), 1e3, "totalAssets correct");
+    }
+
+    /* ══════════════════════════════════════════════════════════════════
+       7. EMERGENCY EXIT
+       ══════════════════════════════════════════════════════════════════ */
+
+    function test_fork_base_emergencyExit_pulls_from_byzantine() public {
+        _deposit(vaultStd, user, DEPOSIT);
+
+        uint256 totalBefore = vaultStd.totalAssets();
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        // All Byzantine shares redeemed (or were already 0 on sandbox)
+        assertEq(IERC4626(BYZANTINE_EUR).balanceOf(address(vaultStd)), 0, "Byzantine shares redeemed");
+        // All funds now idle in vault
+        assertGt(IERC20(EURC_BASE).balanceOf(address(vaultStd)), 0, "EURC in vault");
+        // totalAssets unchanged
+        assertApproxEqAbs(vaultStd.totalAssets(), totalBefore, 1e3, "no value lost");
+        assertTrue(vaultStd.paused(), "vault auto-paused");
+    }
+
+    function test_fork_base_emergencyExit_users_can_withdraw() public {
+        uint256 shares = _deposit(vaultStd, user, DEPOSIT);
+
+        vm.prank(owner);
+        vaultStd.emergencyExitByzantine();
+
+        uint256 balBefore = IERC20(EURC_BASE).balanceOf(user);
+        vm.prank(user);
+        vaultStd.redeem(shares, user, user);
+
+        assertApproxEqAbs(IERC20(EURC_BASE).balanceOf(user), balBefore + DEPOSIT, 1e3);
+    }
+
+    /* ══════════════════════════════════════════════════════════════════
+       8. MULTI-USER
+       ══════════════════════════════════════════════════════════════════ */
+
+    function test_fork_base_multiuser_proportional_shares() public {
+        uint256 s1 = _deposit(vaultStd, user,  DEPOSIT);
+        uint256 s2 = _deposit(vaultStd, user2, DEPOSIT * 2);
+
+        // user2 deposited 2x → should have ~2x shares
+        assertApproxEqAbs(s2, s1 * 2, 1e3);
+    }
+
+    /// @dev Treasury is exempt from the 4h cooldown.
+    ///      Verified by checking maxRedeem immediately after minting shares to treasury.
+    ///      If harvest skipped (no yield on sandbox), we deposit directly to treasury
+    ///      as owner to test the exemption.
+    function test_fork_base_treasury_exempt_from_cooldown() public {
+        // Deposit directly to treasury to give it shares (bypasses cooldown check on receiver)
+        // This works because deposit checks premiumExpiry[receiver], not timestamp.
+        // Treasury is not the depositor — but to mint shares to treasury we must use
+        // _mint directly... instead, just deposit to treasury and verify.
+        uint256 amount = 10e6; // 10 EURC
+        deal(EURC_BASE, owner, amount);
+        vm.startPrank(owner);
+        IERC20(EURC_BASE).approve(address(vaultStd), amount);
+        vaultStd.deposit(amount, treasury);
+        vm.stopPrank();
+
+        uint256 treasuryShares = vaultStd.balanceOf(treasury);
+        assertGt(treasuryShares, 0, "treasury has shares");
+
+        // Treasury deposited so depositTimestamp[treasury] was set.
+        // But treasury IS exempt from cooldown check (owner_ != TREASURY).
+        // maxRedeem should be > 0 immediately.
+        assertGt(vaultStd.maxRedeem(treasury), 0, "treasury exempt from 4h cooldown");
+    }
+
+    /* ─────────────── permit helper ─────────────────────────────────── */
+
+    function _signPermit(
+        address spender_,
+        address owner_,
+        uint256 ownerKey_,
+        uint256 amount_,
+        uint256 deadline_
+    ) internal view returns (uint8 v, bytes32 r, bytes32 s) {
+        bytes32 PERMIT_TYPEHASH =
+            keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+        bytes32 structHash = keccak256(abi.encode(
+            PERMIT_TYPEHASH, owner_, spender_, amount_,
+            ERC20Permit(EURC_BASE).nonces(owner_), deadline_
+        ));
+        bytes32 digest = keccak256(abi.encodePacked(
+            "\x19\x01",
+            ERC20Permit(EURC_BASE).DOMAIN_SEPARATOR(),
+            structHash
+        ));
+        (v, r, s) = vm.sign(ownerKey_, digest);
+    }
+}

--- a/test/mocks/MockByzantineVault.sol
+++ b/test/mocks/MockByzantineVault.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./MockEURC.sol";
+
+/// @notice Minimal ERC-4626 vault standing in for Byzantine VaultV2 in testnet deployments.
+///         No whitelisting, no gates, no fees — pure pass-through with yield simulation.
+contract MockByzantineVault is ERC4626 {
+    constructor(IERC20 asset_) ERC4626(asset_) ERC20("Mock Byzantine EURC Vault", "bEURC") {}
+
+    /// @dev Simulates yield by minting EURC directly into this vault.
+    ///      Increases totalAssets() without minting new shares → share price rises.
+    function simulateYield(uint256 amount) external {
+        MockEURC(asset()).mint(address(this), amount);
+    }
+}

--- a/test/mocks/MockEURC.sol
+++ b/test/mocks/MockEURC.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+
+contract MockEURC is ERC20, ERC20Permit {
+    constructor() ERC20("Mock EURC", "EURC") ERC20Permit("Mock EURC") {
+        _mint(msg.sender, 1_000_000 * 10 ** 6);
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function burn(address from, uint256 amount) external {
+        _burn(from, amount);
+    }
+}


### PR DESCRIPTION
## Summary

- **PaktolVaultV2** : fix fee shares denominator, REQUIRES_AUTH deposit guard, `grantPremiumAccess`, permit support, points threshold
- **DeployBaseV2** : script de déploiement Base Mainnet avec seed dead shares
- **Tests** : suite complète V2 splitée par concern (216 tests unitaires + fork)
- **foundry.toml** : config fork Base ajoutée

## Déployé sur Base Mainnet

| Vault | Adresse | CAP | Symbol |
|-------|---------|-----|--------|
| Paktol Boost EURC | `0xfB83e47aF5b5A059Fb897c358c0ed9f165C523D1` | 5% | pkEURC-B |
| Paktol Standard EURC | `0x3B4379256f62FCd003F94baDC8519e8F3Ddbe795` | 3.5% | pkEURC-S |

- **Owner (Safe)** : `0x3469682e65faFc2d2fAE93f528230B899B183a84`
- **FEE_BPS** : 50 (0.5%)
- **REQUIRES_AUTH** : true
- **Byzantine vault** : `0x061b3aff8e21a9d194ce43cEfc20A0eFf122Ec69`

## Test plan

- [x] 216 tests unitaires passent (`forge test`)
- [x] Fork tests Base Mainnet (avec `--fork-url`)
- [x] Dead shares seedées sur les deux vaults
- [x] Ownership transférée au Safe
- [x] EURC balance vérifiée on-chain