### PR TITLE
test: fix fork block pinning and yield simulation

### DIFF
--- a/test/PaktolVault.erc4626.t.sol
+++ b/test/PaktolVault.erc4626.t.sol
@@ -53,7 +53,9 @@ contract PaktolVaultERC4626ComplianceTest is ERC4626Test {
         vm.warp(block.timestamp + vault.WITHDRAWAL_COOLDOWN() + 1);
     }
 
-    /// @dev Simulate yield by minting EURe idle to vault (totalAssets includes idle balance).
+    /// @dev Simulate yield by minting aTokens to the vault — totalAssets() reads
+    ///      ATOKEN.balanceOf(vault) + _idleBalance, so minting underlying to the vault
+    ///      address is a no-op. pool.simulateYield mints aTokens directly.
     ///      Cap gain to current totalAssets so exchange rate never more than doubles —
     ///      this bounds rounding error to ≤ 1 wei per round-trip (matching _delta_ = 1).
     ///      Loss scenarios skipped — Aave loss handling is in PaktolVault.t.sol.
@@ -64,7 +66,7 @@ contract PaktolVaultERC4626ComplianceTest is ERC4626Test {
                 uint256 cap = IERC4626(_vault_).totalAssets();
                 if (cap == 0) { vm.assume(false); }
                 if (gain > cap) gain = cap;
-                try IMockERC20(_underlying_).mint(_vault_, gain) {} catch { vm.assume(false); }
+                pool.simulateYield(_vault_, gain);
             }
         } else {
             vm.assume(false);

--- a/test/PaktolVault.fork.t.sol
+++ b/test/PaktolVault.fork.t.sol
@@ -47,7 +47,9 @@ contract PaktolVaultForkTest is Test {
             return;
         }
 
-        vm.createSelectFork(rpc);
+        uint256 forkBlock = vm.envOr("GNOSIS_FORK_BLOCK", uint256(0));
+        if (forkBlock == 0) forkBlock = 39_000_000;
+        vm.createSelectFork(rpc, forkBlock);
 
         vault = new PaktolVault(
             IERC20(EURE), "Paktol EUR", "pkEUR", owner,


### PR DESCRIPTION
## Summary

- **Closes #52** — `PaktolVault.fork.t.sol`: fork now pinned to `GNOSIS_FORK_BLOCK` env var (fallback `39_000_000`) for deterministic, reproducible CI runs
- **Closes #51** — `PaktolVault.erc4626.t.sol`: `setUpYield` now uses `pool.simulateYield()` instead of minting underlying to the vault address

## Why the yield fix matters

`totalAssets()` in `PaktolVault` reads `ATOKEN.balanceOf(vault) + _idleBalance` — not the raw ERC20 balance of the vault. Minting underlying directly to `_vault_` had zero effect on `totalAssets()`, making all positive-yield fuzz branches effectively no-ops. `pool.simulateYield(vault, gain)` mints aTokens to the vault, correctly growing `totalAssets()` before round-trip assertions run.